### PR TITLE
[DS-787] Makes sure that annotations have positive width and height

### DIFF
--- a/src/annotation/CreatingAnnotationState.ts
+++ b/src/annotation/CreatingAnnotationState.ts
@@ -44,6 +44,13 @@ export default class CreatingAnnotationState implements IAnnotationState {
         data.getAnnotationData().mark.width !== 0 &&
         data.getAnnotationData().mark.height !== 0
       ) {
+        // make sure width, height are positive numbers
+        const { x, y, width, height } = data.getAnnotationData().mark;
+        data.getAnnotationData().mark.x = x + Math.min(0, width);
+        data.getAnnotationData().mark.y = y + Math.min(0, height);
+        data.getAnnotationData().mark.width = Math.abs(width);
+        data.getAnnotationData().mark.height = Math.abs(height);
+
         this.context.selectedId = data.getAnnotationData().id;
         if (onAnnotationCreate) {
           onAnnotationCreate(data.getAnnotationData());


### PR DESCRIPTION
in previous cases, if you start from bottom right and drag to the top left corner, the x and y would be the bottom-right and the width nd height would be negative. We should not allow such behavior hence we will transform the coordinates to always have x, y be top left corner and positive width and height.

This would address and fix https://cognitedata.atlassian.net/browse/DS-787 since we draw the dialog at the location based on the x, y and width and height with assumption they are all positive numbers.