### PR TITLE
fix: download scale

### DIFF
--- a/src/ReactPictureAnnotation.tsx
+++ b/src/ReactPictureAnnotation.tsx
@@ -616,7 +616,7 @@ export default class ReactPictureAnnotation extends React.Component<
               0,
               width * pageWidth * DOWNLOAD_SCALE,
               height * pageHeight * DOWNLOAD_SCALE,
-              this.scaleState.scale * 2 * DOWNLOAD_SCALE,
+              1,
               true
             );
             bCtx.restore();


### PR DESCRIPTION
When we're downloading a file and zoomed in, that scale would stick on the download
So if you zoomed really far, the annotations would be HUGE
We don't need that, we'll always need it to just be 1.