### PR TITLE
[SPLN-156] Allow to customize annotation boxes

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -11,7 +11,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: rlespinasse/github-slug-action@master
+      - uses: rlespinasse/github-slug-action@v3.x
 
       - name: Print slug variables
         run: |

--- a/src/Cognite/FileViewer.tsx
+++ b/src/Cognite/FileViewer.tsx
@@ -36,6 +36,10 @@ export type ViewerEditCallbacks = {
 
 export type ViewerProps = {
   /**
+   * Custom annotation colors/shapes will be ignored if set to false
+   */
+  allowCustomAnnotations?: boolean;
+  /**
    * File will tell the viewer what file to show.
    */
   file?: FileInfo;
@@ -64,7 +68,8 @@ export type ViewerProps = {
    */
   renderAnnotation?: (
     el: CogniteAnnotation | ProposedCogniteAnnotation,
-    isSelected: boolean
+    isSelected: boolean,
+    allowCustomAnnotations: boolean
   ) => IAnnotation<IRectShapeData>;
   /**
    * Override how an annotation box is drawn on top of the file
@@ -103,6 +108,7 @@ export type ViewerProps = {
 };
 
 export const FileViewer = ({
+  allowCustomAnnotations,
   file: fileFromProps,
   hideLabel = true,
   hoverable = false,
@@ -169,7 +175,8 @@ export const FileViewer = ({
       annotations.map((el) =>
         renderAnnotation(
           el,
-          selectedAnnotation ? isSameResource(el, selectedAnnotation) : false
+          selectedAnnotation ? isSameResource(el, selectedAnnotation) : false,
+          !!allowCustomAnnotations
         )
       ),
     [annotations, selectedAnnotation]
@@ -204,21 +211,20 @@ export const FileViewer = ({
               .split(",")
               .some((el) => box.text.toLowerCase().includes(el))
         )
-        .map(
-          (el) =>
-            ({
-              id: JSON.stringify(el.boundingBox),
-              mark: {
-                x: el.boundingBox.xMin,
-                y: el.boundingBox.yMin,
-                width: el.boundingBox.xMax - el.boundingBox.xMin,
-                height: el.boundingBox.yMax - el.boundingBox.yMin,
-                backgroundColor: `${Colors["midblue-4"].hex()}88`,
-                strokeWidth: 0,
-              },
-              disableClick: true,
-            } as IAnnotation<IRectShapeData>)
-        ),
+        .map((el) => {
+          return {
+            id: JSON.stringify(el.boundingBox),
+            mark: {
+              x: el.boundingBox.xMin,
+              y: el.boundingBox.yMin,
+              width: el.boundingBox.xMax - el.boundingBox.xMin,
+              height: el.boundingBox.yMax - el.boundingBox.yMin,
+              backgroundColor: `${Colors["midblue-4"].hex()}88`,
+              strokeWidth: 0,
+            },
+            disableClick: true,
+          } as IAnnotation<IRectShapeData>;
+        }),
     [textboxes, query]
   );
 

--- a/src/Cognite/FileViewer.tsx
+++ b/src/Cognite/FileViewer.tsx
@@ -36,7 +36,7 @@ export type ViewerEditCallbacks = {
 
 export type ViewerProps = {
   /**
-   * Custom annotation colors/shapes will be ignored if set to false
+   * If true, you can customize the color and shape of annotation boxes.
    */
   allowCustomAnnotations?: boolean;
   /**
@@ -108,7 +108,7 @@ export type ViewerProps = {
 };
 
 export const FileViewer = ({
-  allowCustomAnnotations,
+  allowCustomAnnotations = false,
   file: fileFromProps,
   hideLabel = true,
   hoverable = false,
@@ -220,7 +220,7 @@ export const FileViewer = ({
               width: el.boundingBox.xMax - el.boundingBox.xMin,
               height: el.boundingBox.yMax - el.boundingBox.yMin,
               backgroundColor: `${Colors["midblue-4"].hex()}88`,
-              strokeWidth: 0,
+              strokeWidth: 2,
             },
             disableClick: true,
           } as IAnnotation<IRectShapeData>;

--- a/src/Cognite/FileViewer.tsx
+++ b/src/Cognite/FileViewer.tsx
@@ -211,20 +211,21 @@ export const FileViewer = ({
               .split(",")
               .some((el) => box.text.toLowerCase().includes(el))
         )
-        .map((el) => {
-          return {
-            id: JSON.stringify(el.boundingBox),
-            mark: {
-              x: el.boundingBox.xMin,
-              y: el.boundingBox.yMin,
-              width: el.boundingBox.xMax - el.boundingBox.xMin,
-              height: el.boundingBox.yMax - el.boundingBox.yMin,
-              backgroundColor: `${Colors["midblue-4"].hex()}88`,
-              strokeWidth: 2,
-            },
-            disableClick: true,
-          } as IAnnotation<IRectShapeData>;
-        }),
+        .map(
+          (el) =>
+            ({
+              id: JSON.stringify(el.boundingBox),
+              mark: {
+                x: el.boundingBox.xMin,
+                y: el.boundingBox.yMin,
+                width: el.boundingBox.xMax - el.boundingBox.xMin,
+                height: el.boundingBox.yMax - el.boundingBox.yMin,
+                backgroundColor: `${Colors["midblue-4"].hex()}88`,
+                strokeWidth: 2,
+              },
+              disableClick: true,
+            } as IAnnotation<IRectShapeData>)
+        ),
     [textboxes, query]
   );
 

--- a/src/Cognite/FileViewerUtils.tsx
+++ b/src/Cognite/FileViewerUtils.tsx
@@ -11,6 +11,25 @@ export interface ProposedCogniteAnnotation extends PendingCogniteAnnotation {
   id: string;
 }
 
+export type CustomizableCogniteAnnotation = CogniteAnnotation &
+  ProposedCogniteAnnotation & {
+    mark: {
+      backgroundColor?: string;
+      strokeColor?: string;
+      strokeWidth?: number;
+      draw?: (
+        canvas: CanvasRenderingContext2D,
+        x: number,
+        y: number,
+        width: number,
+        height: number
+      ) => void;
+    };
+  };
+
+/**
+ * If there is no allowCustomAnnotations flag, those are the colors of the annotations.
+ */
 export const selectAnnotationColor = <T extends PendingCogniteAnnotation>(
   annotation: T,
   isSelected = false
@@ -63,11 +82,12 @@ export const selectAnnotationColor = <T extends PendingCogniteAnnotation>(
 };
 
 export const convertCogniteAnnotationToIAnnotation = (
-  el: CogniteAnnotation | ProposedCogniteAnnotation,
-  isSelected = false
+  el: CustomizableCogniteAnnotation,
+  isSelected = false,
+  allowCustomAnnotations: boolean
 ) => {
   const isPending = typeof el.id === "string";
-  return {
+  const annotation = {
     id: `${el.id}`,
     comment: el.label || "No Label",
     page: el.page,
@@ -80,7 +100,18 @@ export const convertCogniteAnnotationToIAnnotation = (
       strokeWidth: 2,
       strokeColor: isPending ? "yellow" : selectAnnotationColor(el, isSelected),
     },
-  } as IAnnotation<IRectShapeData>;
+  } as any;
+
+  if (allowCustomAnnotations) {
+    if (el?.mark?.backgroundColor)
+      annotation.mark.backgroundColor = el.mark.backgroundColor;
+    if (el?.mark?.strokeColor)
+      annotation.mark.strokeColor = el.mark.strokeColor;
+    if (el?.mark?.strokeWidth)
+      annotation.mark.strokeWidth = el.mark.strokeWidth;
+    if (el?.mark?.draw) annotation.mark.draw = el.mark.draw;
+  }
+  return annotation as IAnnotation<IRectShapeData>;
 };
 
 export const isSameResource = (

--- a/src/Cognite/FileViewerUtils.tsx
+++ b/src/Cognite/FileViewerUtils.tsx
@@ -105,10 +105,12 @@ export const convertCogniteAnnotationToIAnnotation = (
   if (allowCustomAnnotations) {
     if (el?.mark?.backgroundColor)
       annotation.mark.backgroundColor = el.mark.backgroundColor;
-    if (el?.mark?.strokeColor)
+    if (el?.mark?.strokeColor) {
       annotation.mark.strokeColor = el.mark.strokeColor;
-    if (el?.mark?.strokeWidth)
+    }
+    if (el?.mark?.strokeWidth !== undefined) {
       annotation.mark.strokeWidth = el.mark.strokeWidth;
+    }
     if (el?.mark?.draw) annotation.mark.draw = el.mark.draw;
   }
   return annotation as IAnnotation<IRectShapeData>;

--- a/stories/cognite.stories.mdx
+++ b/stories/cognite.stories.mdx
@@ -95,6 +95,29 @@ Sometimes you want various views to also share access to the same annotations, p
 
 ## Customized annotations
 
+You can customize annotations via the advanced CogniteFileViewer. To do that, you need to pass an `allowCustomAnnotations` flag to the `<CogniteFileViewer>` component.
+
+When the `allowCustomAnnotations` flag equals `true`, you can pass an additional argument in your annotation object - `mark`. Here you can define your custom annotation shape.
+
+```
+{
+  mark: {
+    backgroundColor?: string; // this must be in hex or string format
+    strokeColor?: string;
+    strokeWidth?: number;
+    draw?: (
+      canvas: CanvasRenderingContext2D,
+      x: number,
+      y: number,
+      width: number,
+      height: number
+    ) => void;
+  }
+}
+```
+
+The `draw()` function allows you to define a canvas and draw any shape you like. Example of what the `draw()` function might look like is in the story below.
+
 <Canvas>
   <Story story={CustomizedAnnotations} />
 </Canvas>

--- a/stories/cognite.stories.mdx
+++ b/stories/cognite.stories.mdx
@@ -12,6 +12,7 @@ import {
   AllowCustomization,
   AllowControlledEditing,
   SplitContextAndViewer,
+  CustomizedAnnotations,
   Playground,
 } from './cognite.stories.tsx';
 
@@ -91,6 +92,12 @@ Sometimes you want various views to also share access to the same annotations, p
 ### Available context props/hooks from `CogniteFileViewer.Context`
 
 <ArgsTable of={stubObserverObj} />
+
+## Customized annotations
+
+<Canvas>
+  <Story story={CustomizedAnnotations} />
+</Canvas>
 
 ## Playground
 

--- a/stories/cognite.stories.tsx
+++ b/stories/cognite.stories.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useMemo } from "react";
 import { action } from "@storybook/addon-actions";
-import { boolean, select, number } from "@storybook/addon-knobs";
+import { boolean, select } from "@storybook/addon-knobs";
 import { CogniteFileViewer, ViewerEditCallbacks } from "../src";
 import {
   imgSdk,
@@ -181,7 +181,7 @@ export const CustomizedAnnotations = () => {
     {
       backgroundColor: "#ff110055",
       strokeColor: "#26ff0055",
-      strokeWidth: number("Stroke width", 0),
+      strokeWidth: 0,
     },
     {
       draw: (
@@ -192,6 +192,7 @@ export const CustomizedAnnotations = () => {
         height: number
       ) => {
         canvas.beginPath();
+        canvas.globalCompositeOperation = "multiply";
         canvas.fillStyle = "#26ff0055";
         canvas.arc(
           x + width / 2,
@@ -219,7 +220,7 @@ export const CustomizedAnnotations = () => {
       );
       setAnnotations(customizedAnnotations);
     })();
-  }, []);
+  }, [mark]);
 
   return (
     <CogniteFileViewer

--- a/stories/cognite.stories.tsx
+++ b/stories/cognite.stories.tsx
@@ -1,21 +1,28 @@
-import React, { useEffect, useState, useMemo } from 'react';
-import { action } from '@storybook/addon-actions';
-import { boolean, select } from '@storybook/addon-knobs';
-import { CogniteFileViewer, ViewerEditCallbacks } from '../src';
-import { imgSdk, imgFile, pdfFile, pdfSdk } from './utils';
+import React, { useEffect, useState, useMemo } from "react";
+import { action } from "@storybook/addon-actions";
+import { boolean, select, number } from "@storybook/addon-knobs";
+import { CogniteFileViewer, ViewerEditCallbacks } from "../src";
+import {
+  imgSdk,
+  imgFile,
+  imgSdkTwoAnnotations,
+  pdfFile,
+  pdfSdk,
+} from "./utils";
 import {
   listAnnotationsForFile,
   CogniteAnnotation,
-} from '@cognite/annotations';
-import { Button } from '@cognite/cogs.js';
+} from "@cognite/annotations";
+import { CustomizableCogniteAnnotation } from "./Cognite/FileViewerUtils";
+import { Button } from "@cognite/cogs.js";
 import {
   useSelectedAnnotation,
   useExtractFromCanvas,
-} from '../src/Cognite/FileViewerContext';
+} from "../src/Cognite/FileViewerContext";
 import {
   useDownloadPDF,
   useZoomControls,
-} from '../src/Cognite/FileViewerContext';
+} from "../src/Cognite/FileViewerContext";
 
 export const AllowCustomization = () => {
   const [annotations, setAnnotations] = useState<CogniteAnnotation[]>([]);
@@ -26,15 +33,15 @@ export const AllowCustomization = () => {
         annotationsFromCdf.concat([
           {
             id: 123,
-            label: 'David',
+            label: "David",
             createdTime: new Date(),
             lastUpdatedTime: new Date(),
-            type: 'tmp_annotation',
-            status: 'unhandled',
+            type: "tmp_annotation",
+            status: "unhandled",
             box: { xMin: 0.1, xMax: 0.2, yMin: 0.1, yMax: 0.2 },
             version: 5,
             page: 1,
-            source: 'tmp',
+            source: "tmp",
           },
         ])
       );
@@ -126,8 +133,8 @@ export const SplitContextAndViewer = () => {
     } = useSelectedAnnotation();
 
     return (
-      <div style={{ width: 200, background: 'white' }}>
-        <Button onClick={() => download!('testing.pdf')}>Download</Button>
+      <div style={{ width: 200, background: "white" }}>
+        <Button onClick={() => download!("testing.pdf")}>Download</Button>
         <Button onClick={() => zoomIn!()}>Zoom In</Button>
         <Button onClick={() => zoomOut!()}>Zoom Out</Button>
         <Button onClick={() => reset!()}>Reset</Button>
@@ -142,8 +149,8 @@ export const SplitContextAndViewer = () => {
         {selectedAnnotation && (
           <img
             style={{
-              objectFit: 'contain',
-              width: '100%',
+              objectFit: "contain",
+              width: "100%",
             }}
             src={extract!(
               selectedAnnotation.box.xMin,
@@ -158,11 +165,71 @@ export const SplitContextAndViewer = () => {
   };
   return (
     <CogniteFileViewer.Provider sdk={pdfSdk}>
-      <div style={{ height: '100%', width: '100%', display: 'flex' }}>
+      <div style={{ height: "100%", width: "100%", display: "flex" }}>
         <AnotherComponent />
         <CogniteFileViewer.FileViewer file={pdfFile} editable={true} />
       </div>
     </CogniteFileViewer.Provider>
+  );
+};
+
+export const CustomizedAnnotations = () => {
+  const [annotations, setAnnotations] = useState<
+    CustomizableCogniteAnnotation[]
+  >([]);
+  const mark = [
+    {
+      backgroundColor: "#ff110055",
+      strokeColor: "#26ff0055",
+      strokeWidth: number("Stroke width", 0),
+    },
+    {
+      draw: (
+        canvas: CanvasRenderingContext2D,
+        x: number,
+        y: number,
+        width: number,
+        height: number
+      ) => {
+        canvas.beginPath();
+        canvas.fillStyle = "#26ff0055";
+        canvas.arc(
+          x + width / 2,
+          y + height / 2,
+          Math.min(height, width) / 2,
+          0,
+          2 * Math.PI
+        );
+        canvas.stroke();
+        canvas.fill();
+      },
+    },
+  ];
+  useEffect(() => {
+    (async () => {
+      const rawAnnotations = await listAnnotationsForFile(
+        imgSdkTwoAnnotations,
+        imgFile
+      );
+      const customizedAnnotations = rawAnnotations.map(
+        (annotation: CustomizableCogniteAnnotation, index: number) => ({
+          ...annotation,
+          mark: mark[index],
+        })
+      );
+      setAnnotations(customizedAnnotations);
+    })();
+  }, []);
+
+  return (
+    <CogniteFileViewer
+      sdk={imgSdk}
+      file={imgFile}
+      disableAutoFetch={true}
+      annotations={annotations}
+      editable={true}
+      allowCustomAnnotations={true}
+    />
   );
 };
 
@@ -171,13 +238,13 @@ export const Playground = () => {
     <CogniteFileViewer
       sdk={pdfSdk}
       file={pdfFile}
-      editable={boolean('Editable', false)}
-      creatable={boolean('Creatable', false)}
-      hideControls={boolean('Hide Controls', false)}
-      hideLabel={boolean('Hide Label', false)}
-      hoverable={boolean('Hoverable', false)}
-      pagination={select('Pagination', ['small', 'normal', false], 'normal')}
-      onAnnotationSelected={action('onAnnotationSelected')}
+      editable={boolean("Editable", false)}
+      creatable={boolean("Creatable", false)}
+      hideControls={boolean("Hide Controls", false)}
+      hideLabel={boolean("Hide Label", false)}
+      hoverable={boolean("Hoverable", false)}
+      pagination={select("Pagination", ["small", "normal", false], "normal")}
+      onAnnotationSelected={action("onAnnotationSelected")}
     />
   );
 };

--- a/stories/resources.tsx
+++ b/stories/resources.tsx
@@ -1,596 +1,636 @@
+export const twoAnnotationsResponse = [
+  {
+    type: "cognite_annotation",
+    subtype: "pnid_annotation",
+    description: "This is a customizable annotation!",
+    metadata: {
+      CDF_ANNOTATION_box:
+        '{"xMin":0.28109384469584436,"yMin":0.15310077519379847,"xMax":0.3489239209872729,"yMax":0.22868217054263568}',
+      CDF_ANNOTATION_file_external_id: "dummy.pdf",
+      CDF_ANNOTATION_resource_external_id: "dummyfile",
+      CDF_ANNOTATION_resource_id: "1233",
+      CDF_ANNOTATION_resource_type: "timeSeries",
+      CDF_ANNOTATION_status: "verified",
+      CDF_ANNOTATION_version: "1",
+    },
+    source: "email:anna.gadacz@cognite.com",
+    id: 1111,
+    lastUpdatedTime: 1598534901556,
+    createdTime: 1598534901556,
+  },
+  {
+    type: "cognite_annotation",
+    subtype: "pnid_annotation",
+    description: "This is another customizable annotation!",
+    metadata: {
+      CDF_ANNOTATION_box:
+        '{"xMin":0.2129383340287385,"yMin":0.3275193798449612,"xMax":0.2608961302530543,"yMax":0.39728682170542634}',
+      CDF_ANNOTATION_file_external_id: "dummy.pdf",
+      CDF_ANNOTATION_resource_external_id: "dummyfile",
+      CDF_ANNOTATION_resource_type: "asset",
+      CDF_ANNOTATION_status: "verified",
+      CDF_ANNOTATION_version: "5",
+    },
+    source: "email:anna.gadacz@cognite.com",
+    id: 2222,
+    lastUpdatedTime: 1598263653461,
+    createdTime: 1598263653461,
+  },
+];
+
 export const response = [
   {
-    type: 'cognite_annotation',
+    type: "cognite_annotation",
     subtype: '"COUNTING OF ""AIR COMPRESSORS"" SPARE PARTS"',
     metadata: {
       CDF_ANNOTATION_box:
         '{"xMin":0.1643835616438356,"yMin":0.21782432299052995,"xMax":0.24566210045662096,"yMax":0.2643155100492985}',
-      CDF_ANNOTATION_file_external_id: 'PH-ME-P-0153-001.pdf',
-      CDF_ANNOTATION_resource_external_id: '8037268543438081',
-      CDF_ANNOTATION_resource_type: 'asset',
-      CDF_ANNOTATION_status: 'deleted',
-      CDF_ANNOTATION_version: '5',
+      CDF_ANNOTATION_file_external_id: "PH-ME-P-0153-001.pdf",
+      CDF_ANNOTATION_resource_external_id: "8037268543438081",
+      CDF_ANNOTATION_resource_type: "asset",
+      CDF_ANNOTATION_status: "deleted",
+      CDF_ANNOTATION_version: "5",
     },
-    source: 'email:david.liu@cognite.com',
+    source: "email:david.liu@cognite.com",
     id: 319968411007907,
     lastUpdatedTime: 1594385231239,
     createdTime: 1594385226659,
   },
   {
-    type: 'cognite_annotation',
-    subtype: 'pnid_annotation',
+    type: "cognite_annotation",
+    subtype: "pnid_annotation",
     description: '"COUNTING OF ""BALLAST/BILGE SYSTEMS"" SPARE PARTS',
     metadata: {
       CDF_ANNOTATION_box:
         '{"xMin":0.26743582306018865,"yMin":0.30558375634517765,"xMax":0.29399407783417947,"yMax":0.36751269035532996}',
-      CDF_ANNOTATION_file_external_id: 'PH-ME-P-0153-001.pdf',
-      CDF_ANNOTATION_resource_external_id: '3851005878284980',
-      CDF_ANNOTATION_resource_type: 'asset',
-      CDF_ANNOTATION_status: 'verified',
-      CDF_ANNOTATION_version: '5',
+      CDF_ANNOTATION_file_external_id: "PH-ME-P-0153-001.pdf",
+      CDF_ANNOTATION_resource_external_id: "3851005878284980",
+      CDF_ANNOTATION_resource_type: "asset",
+      CDF_ANNOTATION_status: "verified",
+      CDF_ANNOTATION_version: "5",
     },
-    source: 'email:arne.kvadsheim@cognite.com',
+    source: "email:arne.kvadsheim@cognite.com",
     id: 352749521886257,
     lastUpdatedTime: 1598359289577,
     createdTime: 1598359289577,
   },
   {
-    type: 'cognite_annotation',
-    subtype: 'pnid_annotation',
-    description: 'Processed-PnID.png',
+    type: "cognite_annotation",
+    subtype: "pnid_annotation",
+    description: "Processed-PnID.png",
     metadata: {
       CDF_ANNOTATION_box:
         '{"xMin":0.6479739313649885,"yMin":0.28594249201277955,"xMax":0.689768095185634,"yMax":0.36741214057507987}',
-      CDF_ANNOTATION_file_external_id: 'PH-ME-P-0153-001.pdf',
-      CDF_ANNOTATION_resource_type: 'file',
-      CDF_ANNOTATION_status: 'verified',
-      CDF_ANNOTATION_version: '5',
+      CDF_ANNOTATION_file_external_id: "PH-ME-P-0153-001.pdf",
+      CDF_ANNOTATION_resource_type: "file",
+      CDF_ANNOTATION_status: "verified",
+      CDF_ANNOTATION_version: "5",
     },
-    source: 'email:arne.kvadsheim@cognite.com',
+    source: "email:arne.kvadsheim@cognite.com",
     id: 406167784064508,
     lastUpdatedTime: 1598350017924,
     createdTime: 1598350017924,
   },
   {
-    type: 'cognite_annotation',
-    subtype: 'pnid_annotation',
-    description: '23-XX-9106',
+    type: "cognite_annotation",
+    subtype: "pnid_annotation",
+    description: "23-XX-9106",
     metadata: {
       CDF_ANNOTATION_box:
         '{"xMax":0.37633541624672445,"xMin":0.3257407780689377,"yMax":0.049315849486887116,"yMin":0.03933865450399088}',
-      CDF_ANNOTATION_file_external_id: 'PH-ME-P-0153-001.pdf',
-      CDF_ANNOTATION_resource_external_id: '4856008121737468',
-      CDF_ANNOTATION_resource_type: 'asset',
-      CDF_ANNOTATION_status: 'unhandled',
-      CDF_ANNOTATION_version: '5',
+      CDF_ANNOTATION_file_external_id: "PH-ME-P-0153-001.pdf",
+      CDF_ANNOTATION_resource_external_id: "4856008121737468",
+      CDF_ANNOTATION_resource_type: "asset",
+      CDF_ANNOTATION_status: "unhandled",
+      CDF_ANNOTATION_version: "5",
     },
-    source: 'job:3425030520931466',
+    source: "job:3425030520931466",
     id: 1026602738726861,
     lastUpdatedTime: 1597233855648,
     createdTime: 1597233855648,
   },
   {
-    type: 'cognite_annotation',
-    subtype: 'pnid_annotation',
-    description: '23-KA-9101',
+    type: "cognite_annotation",
+    subtype: "pnid_annotation",
+    description: "23-KA-9101",
     metadata: {
       CDF_ANNOTATION_box:
         '{"xMax":0.11852449103003426,"xMin":0.06551098568836929,"yMax":0.6778791334093502,"yMin":0.6733181299885975}',
-      CDF_ANNOTATION_file_external_id: 'PH-ME-P-0153-001.pdf',
-      CDF_ANNOTATION_resource_external_id: '3047932288982463',
-      CDF_ANNOTATION_resource_type: 'asset',
-      CDF_ANNOTATION_status: 'unhandled',
-      CDF_ANNOTATION_version: '5',
+      CDF_ANNOTATION_file_external_id: "PH-ME-P-0153-001.pdf",
+      CDF_ANNOTATION_resource_external_id: "3047932288982463",
+      CDF_ANNOTATION_resource_type: "asset",
+      CDF_ANNOTATION_status: "unhandled",
+      CDF_ANNOTATION_version: "5",
     },
-    source: 'job:3425030520931466',
+    source: "job:3425030520931466",
     id: 1778804844587294,
     lastUpdatedTime: 1597233855648,
     createdTime: 1597233855648,
   },
   {
-    type: 'cognite_annotation',
-    subtype: 'CCLP',
+    type: "cognite_annotation",
+    subtype: "CCLP",
     metadata: {
       CDF_ANNOTATION_box:
         '{"xMin":0.5226363443503919,"yMin":0.10168721498546478,"xMax":0.5498284259880304,"yMax":0.13533544767330755}',
-      CDF_ANNOTATION_file_external_id: 'PH-ME-P-0153-001.pdf',
-      CDF_ANNOTATION_status: 'deleted',
-      CDF_ANNOTATION_version: '5',
+      CDF_ANNOTATION_file_external_id: "PH-ME-P-0153-001.pdf",
+      CDF_ANNOTATION_status: "deleted",
+      CDF_ANNOTATION_version: "5",
     },
-    source: 'email:david.liu@cognite.com',
+    source: "email:david.liu@cognite.com",
     id: 2079034067156735,
     lastUpdatedTime: 1593776434475,
     createdTime: 1593776405037,
   },
   {
-    type: 'cognite_annotation',
-    subtype: 'pnid_annotation',
-    description: 'hellow',
+    type: "cognite_annotation",
+    subtype: "pnid_annotation",
+    description: "hellow",
     metadata: {
       CDF_ANNOTATION_box:
         '{"xMin":0.28109384469584436,"yMin":0.15310077519379847,"xMax":0.3489239209872729,"yMax":0.22868217054263568}',
-      CDF_ANNOTATION_file_external_id: 'PH-ME-P-0153-001.pdf',
-      CDF_ANNOTATION_resource_external_id: '00ADD0001/B1/1mMid',
-      CDF_ANNOTATION_resource_id: '7882260137862254',
-      CDF_ANNOTATION_resource_type: 'timeSeries',
-      CDF_ANNOTATION_status: 'verified',
-      CDF_ANNOTATION_version: '5',
+      CDF_ANNOTATION_file_external_id: "PH-ME-P-0153-001.pdf",
+      CDF_ANNOTATION_resource_external_id: "00ADD0001/B1/1mMid",
+      CDF_ANNOTATION_resource_id: "7882260137862254",
+      CDF_ANNOTATION_resource_type: "timeSeries",
+      CDF_ANNOTATION_status: "verified",
+      CDF_ANNOTATION_version: "5",
     },
-    source: 'email:david.liu@cognite.com',
+    source: "email:david.liu@cognite.com",
     id: 2234609746333692,
     lastUpdatedTime: 1598534901556,
     createdTime: 1598534901556,
   },
   {
-    type: 'cognite_annotation',
-    subtype: 'pnid_annotation',
-    description: '23-PT-92540',
+    type: "cognite_annotation",
+    subtype: "pnid_annotation",
+    description: "23-PT-92540",
     metadata: {
       CDF_ANNOTATION_box:
         '{"xMax":0.07518645434388228,"xMin":0.05220721628703891,"yMax":0.7594070695553023,"yMin":0.7548460661345496}',
-      CDF_ANNOTATION_file_external_id: 'PH-ME-P-0153-001.pdf',
-      CDF_ANNOTATION_resource_external_id: '8531327771472325',
-      CDF_ANNOTATION_resource_type: 'asset',
-      CDF_ANNOTATION_status: 'unhandled',
-      CDF_ANNOTATION_version: '5',
+      CDF_ANNOTATION_file_external_id: "PH-ME-P-0153-001.pdf",
+      CDF_ANNOTATION_resource_external_id: "8531327771472325",
+      CDF_ANNOTATION_resource_type: "asset",
+      CDF_ANNOTATION_status: "unhandled",
+      CDF_ANNOTATION_version: "5",
     },
-    source: 'job:3425030520931466',
+    source: "job:3425030520931466",
     id: 2555523053450316,
     lastUpdatedTime: 1597233855648,
     createdTime: 1597233855648,
   },
   {
-    type: 'cognite_annotation',
-    subtype: 'pnid_annotation',
-    description: 'David',
+    type: "cognite_annotation",
+    subtype: "pnid_annotation",
+    description: "David",
     metadata: {
       CDF_ANNOTATION_box:
         '{"xMin":0.6602020593193312,"yMin":0.4382978723404255,"xMax":0.7293973149877747,"yMax":0.5382978723404255}',
-      CDF_ANNOTATION_file_external_id: 'PH-ME-P-0153-001.pdf',
-      CDF_ANNOTATION_status: 'verified',
-      CDF_ANNOTATION_version: '5',
+      CDF_ANNOTATION_file_external_id: "PH-ME-P-0153-001.pdf",
+      CDF_ANNOTATION_status: "verified",
+      CDF_ANNOTATION_version: "5",
     },
-    source: 'email:david.liu@cognite.com',
+    source: "email:david.liu@cognite.com",
     id: 2742838378943997,
     lastUpdatedTime: 1598885044085,
     createdTime: 1598885044085,
   },
   {
-    type: 'cognite_annotation',
-    subtype: 'pnid_annotation',
+    type: "cognite_annotation",
+    subtype: "pnid_annotation",
     description: '"COUNTING OF ""AIR CONDITION/REFRIG.SYSTEM"" SPARE',
     metadata: {
       CDF_ANNOTATION_box:
         '{"xMin":0.047450606254721375,"yMin":0.21547699274784402,"xMax":0.10618786402504735,"yMax":0.2479283470773386}',
-      CDF_ANNOTATION_file_external_id: 'PH-ME-P-0153-001.pdf',
-      CDF_ANNOTATION_resource_external_id: '5832795727304606',
-      CDF_ANNOTATION_resource_type: 'asset',
-      CDF_ANNOTATION_status: 'verified',
-      CDF_ANNOTATION_version: '5',
+      CDF_ANNOTATION_file_external_id: "PH-ME-P-0153-001.pdf",
+      CDF_ANNOTATION_resource_external_id: "5832795727304606",
+      CDF_ANNOTATION_resource_type: "asset",
+      CDF_ANNOTATION_status: "verified",
+      CDF_ANNOTATION_version: "5",
     },
-    source: 'email:edel.andersen@cognite.com',
+    source: "email:edel.andersen@cognite.com",
     id: 3027709133309114,
     lastUpdatedTime: 1597742316578,
     createdTime: 1597742316578,
   },
   {
-    type: 'cognite_annotation',
-    subtype: 'pnid_annotation',
-    description: '70 GAS 5722 SERIES GROUP',
+    type: "cognite_annotation",
+    subtype: "pnid_annotation",
+    description: "70 GAS 5722 SERIES GROUP",
     metadata: {
       CDF_ANNOTATION_box:
         '{"xMin":0.2129383340287385,"yMin":0.3275193798449612,"xMax":0.2608961302530543,"yMax":0.39728682170542634}',
-      CDF_ANNOTATION_file_external_id: 'PH-ME-P-0153-001.pdf',
-      CDF_ANNOTATION_resource_external_id: 'ALV_70 GAS 5722 SERIES GROUP',
-      CDF_ANNOTATION_resource_type: 'asset',
-      CDF_ANNOTATION_status: 'verified',
-      CDF_ANNOTATION_version: '5',
+      CDF_ANNOTATION_file_external_id: "PH-ME-P-0153-001.pdf",
+      CDF_ANNOTATION_resource_external_id: "ALV_70 GAS 5722 SERIES GROUP",
+      CDF_ANNOTATION_resource_type: "asset",
+      CDF_ANNOTATION_status: "verified",
+      CDF_ANNOTATION_version: "5",
     },
-    source: 'email:edel.andersen@cognite.com',
+    source: "email:edel.andersen@cognite.com",
     id: 3043749364243936,
     lastUpdatedTime: 1598263653461,
     createdTime: 1598263653461,
   },
   {
-    type: 'cognite_annotation',
+    type: "cognite_annotation",
     subtype: '"COUNTING OF ""AIR COMPRESSORS"" SPARE PARTS"',
     metadata: {
       CDF_ANNOTATION_box:
         '{"xMin":0.19701986754966885,"yMin":0.2775926026323252,"xMax":0.42549668874172186,"yMax":0.4016725190585017}',
-      CDF_ANNOTATION_file_external_id: 'PH-ME-P-0153-001.pdf',
-      CDF_ANNOTATION_resource_external_id: '8037268543438081',
-      CDF_ANNOTATION_resource_type: 'asset',
-      CDF_ANNOTATION_status: 'deleted',
-      CDF_ANNOTATION_version: '5',
+      CDF_ANNOTATION_file_external_id: "PH-ME-P-0153-001.pdf",
+      CDF_ANNOTATION_resource_external_id: "8037268543438081",
+      CDF_ANNOTATION_resource_type: "asset",
+      CDF_ANNOTATION_status: "deleted",
+      CDF_ANNOTATION_version: "5",
     },
-    source: 'email:david.liu@cognite.com',
+    source: "email:david.liu@cognite.com",
     id: 3141341377605724,
     lastUpdatedTime: 1594659539401,
     createdTime: 1594659534171,
   },
   {
-    type: 'cognite_annotation',
-    subtype: 'pnid_annotation',
-    description: '23-PT-96150-01',
+    type: "cognite_annotation",
+    subtype: "pnid_annotation",
+    description: "23-PT-96150-01",
     metadata: {
       CDF_ANNOTATION_box:
         '{"xMax":0.23523483168715986,"xMin":0.2009675468655513,"yMax":0.7730900798175598,"yMin":0.7682440136830103}',
-      CDF_ANNOTATION_file_external_id: 'PH-ME-P-0153-001.pdf',
-      CDF_ANNOTATION_resource_external_id: '4050790831683279',
-      CDF_ANNOTATION_resource_type: 'asset',
-      CDF_ANNOTATION_status: 'unhandled',
-      CDF_ANNOTATION_version: '5',
+      CDF_ANNOTATION_file_external_id: "PH-ME-P-0153-001.pdf",
+      CDF_ANNOTATION_resource_external_id: "4050790831683279",
+      CDF_ANNOTATION_resource_type: "asset",
+      CDF_ANNOTATION_status: "unhandled",
+      CDF_ANNOTATION_version: "5",
     },
-    source: 'job:3425030520931466',
+    source: "job:3425030520931466",
     id: 3486315845341421,
     lastUpdatedTime: 1597233855648,
     createdTime: 1597233855648,
   },
   {
-    type: 'cognite_annotation',
-    subtype: 'pnid_annotation',
-    description: 'anything new',
+    type: "cognite_annotation",
+    subtype: "pnid_annotation",
+    description: "anything new",
     metadata: {
       CDF_ANNOTATION_box:
         '{"xMin":0.48999309868875085,"yMin":0.41412676770955814,"xMax":0.5376121463077984,"yMax":0.4902416781488134}',
-      CDF_ANNOTATION_description: 'asdf',
-      CDF_ANNOTATION_file_external_id: 'PH-ME-P-0153-001.pdf',
-      CDF_ANNOTATION_status: 'verified',
-      CDF_ANNOTATION_version: '5',
+      CDF_ANNOTATION_description: "asdf",
+      CDF_ANNOTATION_file_external_id: "PH-ME-P-0153-001.pdf",
+      CDF_ANNOTATION_status: "verified",
+      CDF_ANNOTATION_version: "5",
     },
-    source: 'email:david.liu@cognite.com',
+    source: "email:david.liu@cognite.com",
     id: 3819603829895073,
     lastUpdatedTime: 1598452419691,
     createdTime: 1598452419691,
   },
   {
-    type: 'cognite_annotation',
-    subtype: 'pnid_annotation',
-    description: 'whoot',
+    type: "cognite_annotation",
+    subtype: "pnid_annotation",
+    description: "whoot",
     metadata: {
       CDF_ANNOTATION_box:
         '{"xMin":0.42378241619228335,"yMin":0.24105032505362073,"xMax":0.4509803921568627,"yMax":0.2741457930087711}',
-      CDF_ANNOTATION_file_external_id: 'PH-ME-P-0153-001.pdf',
-      CDF_ANNOTATION_resource_external_id: 'ALV_11691023',
-      CDF_ANNOTATION_resource_id: '5950976544660549',
-      CDF_ANNOTATION_resource_type: 'asset',
-      CDF_ANNOTATION_status: 'verified',
-      CDF_ANNOTATION_version: '5',
+      CDF_ANNOTATION_file_external_id: "PH-ME-P-0153-001.pdf",
+      CDF_ANNOTATION_resource_external_id: "ALV_11691023",
+      CDF_ANNOTATION_resource_id: "5950976544660549",
+      CDF_ANNOTATION_resource_type: "asset",
+      CDF_ANNOTATION_status: "verified",
+      CDF_ANNOTATION_version: "5",
     },
-    source: 'email:david.liu@cognite.com',
+    source: "email:david.liu@cognite.com",
     id: 4340578490443311,
     lastUpdatedTime: 1598027018229,
     createdTime: 1598027018229,
   },
   {
-    type: 'cognite_annotation',
-    subtype: 'pnid_annotation',
+    type: "cognite_annotation",
+    subtype: "pnid_annotation",
     description: '"COUNTING OF ""BOW THRUSTER UNIT"" SPARE PARTS"',
     metadata: {
       CDF_ANNOTATION_box:
         '{"xMin":0.21567877952727085,"yMin":0.48837209302325585,"xMax":0.2841899169905791,"yMax":0.5155038759689923}',
-      CDF_ANNOTATION_file_external_id: 'PH-ME-P-0153-001.pdf',
-      CDF_ANNOTATION_resource_external_id: '121277937177483',
-      CDF_ANNOTATION_resource_type: 'asset',
-      CDF_ANNOTATION_status: 'verified',
-      CDF_ANNOTATION_version: '5',
+      CDF_ANNOTATION_file_external_id: "PH-ME-P-0153-001.pdf",
+      CDF_ANNOTATION_resource_external_id: "121277937177483",
+      CDF_ANNOTATION_resource_type: "asset",
+      CDF_ANNOTATION_status: "verified",
+      CDF_ANNOTATION_version: "5",
     },
-    source: 'email:edel.andersen@cognite.com',
+    source: "email:edel.andersen@cognite.com",
     id: 4532665115120792,
     lastUpdatedTime: 1598257244235,
     createdTime: 1598257244235,
   },
   {
-    type: 'cognite_annotation',
-    subtype: '23-PT-92539',
+    type: "cognite_annotation",
+    subtype: "23-PT-92539",
     metadata: {
       CDF_ANNOTATION_box:
         '{"xMax":0.6099576698246322,"xMin":0.5934287442047974,"yMax":0.6100342075256556,"yMin":0.5935005701254276}',
-      CDF_ANNOTATION_file_external_id: 'PH-ME-P-0153-001.pdf',
-      CDF_ANNOTATION_resource_external_id: '3147733389929639',
-      CDF_ANNOTATION_resource_type: 'asset',
-      CDF_ANNOTATION_status: 'deleted',
-      CDF_ANNOTATION_version: '5',
+      CDF_ANNOTATION_file_external_id: "PH-ME-P-0153-001.pdf",
+      CDF_ANNOTATION_resource_external_id: "3147733389929639",
+      CDF_ANNOTATION_resource_type: "asset",
+      CDF_ANNOTATION_status: "deleted",
+      CDF_ANNOTATION_version: "5",
     },
-    source: 'job:8624150428511301',
+    source: "job:8624150428511301",
     id: 4620121021621140,
     lastUpdatedTime: 1594174366120,
     createdTime: 1593788143307,
   },
   {
-    type: 'cognite_annotation',
-    subtype: 'pnid_annotation',
+    type: "cognite_annotation",
+    subtype: "pnid_annotation",
     description: '"COUNTING OF ""AIR COMPRESSORS"" SPARE PARTS"',
     metadata: {
       CDF_ANNOTATION_box:
         '{"xMin":0.18689691032251188,"yMin":0.22352492862155865,"xMax":0.22544323573428832,"yMax":0.25545706128178136}',
-      CDF_ANNOTATION_file_external_id: 'PH-ME-P-0153-001.pdf',
-      CDF_ANNOTATION_resource_external_id: '8037268543438081',
-      CDF_ANNOTATION_resource_type: 'asset',
-      CDF_ANNOTATION_status: 'verified',
-      CDF_ANNOTATION_version: '5',
+      CDF_ANNOTATION_file_external_id: "PH-ME-P-0153-001.pdf",
+      CDF_ANNOTATION_resource_external_id: "8037268543438081",
+      CDF_ANNOTATION_resource_type: "asset",
+      CDF_ANNOTATION_status: "verified",
+      CDF_ANNOTATION_version: "5",
     },
-    source: 'email:edel.andersen@cognite.com',
+    source: "email:edel.andersen@cognite.com",
     id: 4684462763263038,
     lastUpdatedTime: 1597913010903,
     createdTime: 1597913010903,
   },
   {
-    type: 'cognite_annotation',
-    subtype: 'pnid_annotation',
-    description: '23-KA-9101-M01',
+    type: "cognite_annotation",
+    subtype: "pnid_annotation",
+    description: "23-KA-9101-M01",
     metadata: {
       CDF_ANNOTATION_box:
         '{"xMax":0.49828663575891957,"xMin":0.42572062084257206,"yMax":0.8469213226909921,"yMin":0.8358038768529077}',
-      CDF_ANNOTATION_file_external_id: 'PH-ME-P-0153-001.pdf',
-      CDF_ANNOTATION_resource_external_id: '6191827428964450',
-      CDF_ANNOTATION_resource_type: 'asset',
-      CDF_ANNOTATION_status: 'unhandled',
-      CDF_ANNOTATION_version: '5',
+      CDF_ANNOTATION_file_external_id: "PH-ME-P-0153-001.pdf",
+      CDF_ANNOTATION_resource_external_id: "6191827428964450",
+      CDF_ANNOTATION_resource_type: "asset",
+      CDF_ANNOTATION_status: "unhandled",
+      CDF_ANNOTATION_version: "5",
     },
-    source: 'job:3425030520931466',
+    source: "job:3425030520931466",
     id: 5284005858465797,
     lastUpdatedTime: 1597233855648,
     createdTime: 1597233855648,
   },
   {
-    type: 'cognite_annotation',
+    type: "cognite_annotation",
     subtype: '"COUNTING OF ""AIR COMPRESSORS"" SPARE PARTS"',
     metadata: {
       CDF_ANNOTATION_box:
         '{"xMin":0.41826484018264837,"yMin":0.23848707279442705,"xMax":0.45388127853881277,"yMax":0.27593830681399056}',
-      CDF_ANNOTATION_file_external_id: 'PH-ME-P-0153-001.pdf',
-      CDF_ANNOTATION_status: 'deleted',
-      CDF_ANNOTATION_version: '5',
+      CDF_ANNOTATION_file_external_id: "PH-ME-P-0153-001.pdf",
+      CDF_ANNOTATION_status: "deleted",
+      CDF_ANNOTATION_version: "5",
     },
-    source: 'email:david.liu@cognite.com',
+    source: "email:david.liu@cognite.com",
     id: 5368397546996716,
     lastUpdatedTime: 1594385044497,
     createdTime: 1594384881933,
   },
   {
-    type: 'cognite_annotation',
-    subtype: '23-HV-92540-03',
+    type: "cognite_annotation",
+    subtype: "23-HV-92540-03",
     metadata: {
       CDF_ANNOTATION_box:
         '{"xMax":0.681112678895384,"xMin":0.6609554525297319,"yMax":0.16733181299885974,"yMin":0.15108323831242873}',
-      CDF_ANNOTATION_file_external_id: 'PH-ME-P-0153-001.pdf',
-      CDF_ANNOTATION_resource_external_id: '8880835337562442',
-      CDF_ANNOTATION_resource_type: 'asset',
-      CDF_ANNOTATION_status: 'deleted',
-      CDF_ANNOTATION_version: '5',
+      CDF_ANNOTATION_file_external_id: "PH-ME-P-0153-001.pdf",
+      CDF_ANNOTATION_resource_external_id: "8880835337562442",
+      CDF_ANNOTATION_resource_type: "asset",
+      CDF_ANNOTATION_status: "deleted",
+      CDF_ANNOTATION_version: "5",
     },
-    source: 'job:8624150428511301',
+    source: "job:8624150428511301",
     id: 5457097755247349,
     lastUpdatedTime: 1594174347577,
     createdTime: 1593788143307,
   },
   {
-    type: 'cognite_annotation',
-    subtype: 'pnid_annotation',
-    description: '23-PT-96149-02',
+    type: "cognite_annotation",
+    subtype: "pnid_annotation",
+    description: "23-PT-96149-02",
     metadata: {
       CDF_ANNOTATION_box:
         '{"xMax":0.18967950010078613,"xMin":0.15521064301552107,"yMax":0.7730900798175598,"yMin":0.7682440136830103}',
-      CDF_ANNOTATION_file_external_id: 'PH-ME-P-0153-001.pdf',
-      CDF_ANNOTATION_resource_external_id: '6223287279641772',
-      CDF_ANNOTATION_resource_type: 'asset',
-      CDF_ANNOTATION_status: 'unhandled',
-      CDF_ANNOTATION_version: '5',
+      CDF_ANNOTATION_file_external_id: "PH-ME-P-0153-001.pdf",
+      CDF_ANNOTATION_resource_external_id: "6223287279641772",
+      CDF_ANNOTATION_resource_type: "asset",
+      CDF_ANNOTATION_status: "unhandled",
+      CDF_ANNOTATION_version: "5",
     },
-    source: 'job:3425030520931466',
+    source: "job:3425030520931466",
     id: 6285456885371154,
     lastUpdatedTime: 1597233855648,
     createdTime: 1597233855648,
   },
   {
-    type: 'cognite_annotation',
-    subtype: 'pnid_annotation',
-    description: '23-XX-9106',
+    type: "cognite_annotation",
+    subtype: "pnid_annotation",
+    description: "23-XX-9106",
     metadata: {
       CDF_ANNOTATION_box:
         '{"xMax":0.6730497883491232,"xMin":0.6186252771618626,"yMax":0.7924743443557583,"yMin":0.7813568985176739}',
-      CDF_ANNOTATION_file_external_id: 'PH-ME-P-0153-001.pdf',
-      CDF_ANNOTATION_resource_external_id: '4856008121737468',
-      CDF_ANNOTATION_resource_type: 'asset',
-      CDF_ANNOTATION_status: 'unhandled',
-      CDF_ANNOTATION_version: '5',
+      CDF_ANNOTATION_file_external_id: "PH-ME-P-0153-001.pdf",
+      CDF_ANNOTATION_resource_external_id: "4856008121737468",
+      CDF_ANNOTATION_resource_type: "asset",
+      CDF_ANNOTATION_status: "unhandled",
+      CDF_ANNOTATION_version: "5",
     },
-    source: 'job:3425030520931466',
+    source: "job:3425030520931466",
     id: 6720718229405733,
     lastUpdatedTime: 1597233855648,
     createdTime: 1597233855648,
   },
   {
-    type: 'cognite_annotation',
-    subtype: 'pnid_annotation',
-    description: '23-PT-92512',
+    type: "cognite_annotation",
+    subtype: "pnid_annotation",
+    description: "23-PT-92512",
     metadata: {
       CDF_ANNOTATION_box:
         '{"xMax":0.0888933682725257,"xMin":0.06067325136061278,"yMax":0.6185860889395667,"yMin":0.6137400228050172}',
-      CDF_ANNOTATION_file_external_id: 'PH-ME-P-0153-001.pdf',
-      CDF_ANNOTATION_resource_external_id: '2814662602621825',
-      CDF_ANNOTATION_resource_type: 'asset',
-      CDF_ANNOTATION_status: 'unhandled',
-      CDF_ANNOTATION_version: '5',
+      CDF_ANNOTATION_file_external_id: "PH-ME-P-0153-001.pdf",
+      CDF_ANNOTATION_resource_external_id: "2814662602621825",
+      CDF_ANNOTATION_resource_type: "asset",
+      CDF_ANNOTATION_status: "unhandled",
+      CDF_ANNOTATION_version: "5",
     },
-    source: 'job:3425030520931466',
+    source: "job:3425030520931466",
     id: 7508866173707239,
     lastUpdatedTime: 1597233855648,
     createdTime: 1597233855648,
   },
   {
-    type: 'cognite_annotation',
-    subtype: '23-HV-92541-05',
+    type: "cognite_annotation",
+    subtype: "23-HV-92541-05",
     metadata: {
       CDF_ANNOTATION_box:
         '{"xMax":0.734126184237049,"xMin":0.7153799637169925,"yMax":0.3218358038768529,"yMin":0.30530216647662495}',
-      CDF_ANNOTATION_file_external_id: 'PH-ME-P-0153-001.pdf',
-      CDF_ANNOTATION_resource_external_id: '1351180831192986',
-      CDF_ANNOTATION_resource_type: 'asset',
-      CDF_ANNOTATION_status: 'deleted',
-      CDF_ANNOTATION_version: '5',
+      CDF_ANNOTATION_file_external_id: "PH-ME-P-0153-001.pdf",
+      CDF_ANNOTATION_resource_external_id: "1351180831192986",
+      CDF_ANNOTATION_resource_type: "asset",
+      CDF_ANNOTATION_status: "deleted",
+      CDF_ANNOTATION_version: "5",
     },
-    source: 'job:8624150428511301',
+    source: "job:8624150428511301",
     id: 7639416011454431,
     lastUpdatedTime: 1594139107925,
     createdTime: 1593788143307,
   },
   {
-    type: 'cognite_annotation',
-    subtype: 'pnid_annotation',
-    description: '23-KA-9101',
+    type: "cognite_annotation",
+    subtype: "pnid_annotation",
+    description: "23-KA-9101",
     metadata: {
       CDF_ANNOTATION_box:
         '{"xMax":0.17274742995363837,"xMin":0.1324329772223342,"yMax":0.7927594070695553,"yMin":0.7879133409350058}',
-      CDF_ANNOTATION_file_external_id: 'PH-ME-P-0153-001.pdf',
-      CDF_ANNOTATION_resource_external_id: '3047932288982463',
-      CDF_ANNOTATION_resource_type: 'asset',
-      CDF_ANNOTATION_status: 'unhandled',
-      CDF_ANNOTATION_version: '5',
+      CDF_ANNOTATION_file_external_id: "PH-ME-P-0153-001.pdf",
+      CDF_ANNOTATION_resource_external_id: "3047932288982463",
+      CDF_ANNOTATION_resource_type: "asset",
+      CDF_ANNOTATION_status: "unhandled",
+      CDF_ANNOTATION_version: "5",
     },
-    source: 'job:3425030520931466',
+    source: "job:3425030520931466",
     id: 7701769820871487,
     lastUpdatedTime: 1597233855648,
     createdTime: 1597233855648,
   },
   {
-    type: 'cognite_annotation',
-    subtype: 'pnid_annotation',
+    type: "cognite_annotation",
+    subtype: "pnid_annotation",
     description: '"COUNTING OF ""BOILER"" SPARE PARTS"',
     metadata: {
       CDF_ANNOTATION_box:
         '{"xMin":0.31813890878043405,"yMin":0.3498402555910543,"xMax":0.3497669246447064,"yMax":0.402555910543131}',
-      CDF_ANNOTATION_file_external_id: 'PH-ME-P-0153-001.pdf',
-      CDF_ANNOTATION_resource_external_id: '7405826029540927',
-      CDF_ANNOTATION_resource_type: 'asset',
-      CDF_ANNOTATION_status: 'verified',
-      CDF_ANNOTATION_version: '5',
+      CDF_ANNOTATION_file_external_id: "PH-ME-P-0153-001.pdf",
+      CDF_ANNOTATION_resource_external_id: "7405826029540927",
+      CDF_ANNOTATION_resource_type: "asset",
+      CDF_ANNOTATION_status: "verified",
+      CDF_ANNOTATION_version: "5",
     },
-    source: 'email:arne.kvadsheim@cognite.com',
+    source: "email:arne.kvadsheim@cognite.com",
     id: 7845953982940547,
     lastUpdatedTime: 1598351231073,
     createdTime: 1598351231073,
   },
   {
-    type: 'cognite_annotation',
-    subtype: 'PH-S-1305',
+    type: "cognite_annotation",
+    subtype: "PH-S-1305",
     metadata: {
       CDF_ANNOTATION_box:
         '{"xMax":0.4663865566253662,"xMin":0.4478991627693176,"yMax":0.3876337707042694,"yMin":0.3781212866306305}',
-      CDF_ANNOTATION_file_external_id: 'PH-ME-P-0153-001.pdf',
-      CDF_ANNOTATION_resource_external_id: '5326102006389244',
-      CDF_ANNOTATION_resource_type: 'asset',
-      CDF_ANNOTATION_status: 'deleted',
-      CDF_ANNOTATION_version: '5',
+      CDF_ANNOTATION_file_external_id: "PH-ME-P-0153-001.pdf",
+      CDF_ANNOTATION_resource_external_id: "5326102006389244",
+      CDF_ANNOTATION_resource_type: "asset",
+      CDF_ANNOTATION_status: "deleted",
+      CDF_ANNOTATION_version: "5",
     },
-    source: 'job:862631401852743',
+    source: "job:862631401852743",
     id: 7878358707446333,
     lastUpdatedTime: 1593419148471,
     createdTime: 1593002142525,
   },
   {
-    type: 'cognite_annotation',
-    subtype: 'pnid_annotation',
-    description: '23-KA-9101',
+    type: "cognite_annotation",
+    subtype: "pnid_annotation",
+    description: "23-KA-9101",
     metadata: {
       CDF_ANNOTATION_box:
         '{"xMax":0.1535980649062689,"xMin":0.10098770409191696,"yMax":0.6847206385404789,"yMin":0.6798745724059293}',
-      CDF_ANNOTATION_file_external_id: 'PH-ME-P-0153-001.pdf',
-      CDF_ANNOTATION_resource_external_id: '3047932288982463',
-      CDF_ANNOTATION_resource_type: 'asset',
-      CDF_ANNOTATION_status: 'unhandled',
-      CDF_ANNOTATION_version: '5',
+      CDF_ANNOTATION_file_external_id: "PH-ME-P-0153-001.pdf",
+      CDF_ANNOTATION_resource_external_id: "3047932288982463",
+      CDF_ANNOTATION_resource_type: "asset",
+      CDF_ANNOTATION_status: "unhandled",
+      CDF_ANNOTATION_version: "5",
     },
-    source: 'job:3425030520931466',
+    source: "job:3425030520931466",
     id: 7900432774432440,
     lastUpdatedTime: 1597233855648,
     createdTime: 1597233855648,
   },
   {
-    type: 'cognite_annotation',
-    subtype: 'PH-S-1305',
+    type: "cognite_annotation",
+    subtype: "PH-S-1305",
     metadata: {
       CDF_ANNOTATION_box:
         '{"xMax":0.4663865566253662,"xMin":0.4478991627693176,"yMax":0.3876337707042694,"yMin":0.3781212866306305}',
-      CDF_ANNOTATION_file_external_id: 'PH-ME-P-0153-001.pdf',
-      CDF_ANNOTATION_resource_external_id: '5326102006389244',
-      CDF_ANNOTATION_resource_type: 'asset',
-      CDF_ANNOTATION_status: 'deleted',
-      CDF_ANNOTATION_version: '5',
+      CDF_ANNOTATION_file_external_id: "PH-ME-P-0153-001.pdf",
+      CDF_ANNOTATION_resource_external_id: "5326102006389244",
+      CDF_ANNOTATION_resource_type: "asset",
+      CDF_ANNOTATION_status: "deleted",
+      CDF_ANNOTATION_version: "5",
     },
-    source: 'job:6277962336874576',
+    source: "job:6277962336874576",
     id: 8186274386717231,
     lastUpdatedTime: 1593419134842,
     createdTime: 1592999397092,
   },
   {
-    type: 'cognite_annotation',
-    subtype: 'pnid_annotation',
-    description: '23-KA-9101',
+    type: "cognite_annotation",
+    subtype: "pnid_annotation",
+    description: "23-KA-9101",
     metadata: {
       CDF_ANNOTATION_box:
         '{"xMax":0.5371900826446281,"xMin":0.4878048780487805,"yMax":0.049885974914481185,"yMin":0.03990877993158496}',
-      CDF_ANNOTATION_file_external_id: 'PH-ME-P-0153-001.pdf',
-      CDF_ANNOTATION_resource_external_id: '3047932288982463',
-      CDF_ANNOTATION_resource_type: 'asset',
-      CDF_ANNOTATION_status: 'unhandled',
-      CDF_ANNOTATION_version: '5',
+      CDF_ANNOTATION_file_external_id: "PH-ME-P-0153-001.pdf",
+      CDF_ANNOTATION_resource_external_id: "3047932288982463",
+      CDF_ANNOTATION_resource_type: "asset",
+      CDF_ANNOTATION_status: "unhandled",
+      CDF_ANNOTATION_version: "5",
     },
-    source: 'job:3425030520931466',
+    source: "job:3425030520931466",
     id: 8308402605709573,
     lastUpdatedTime: 1597233855648,
     createdTime: 1597233855648,
   },
   {
-    type: 'cognite_annotation',
-    subtype: 'pnid_annotation',
-    description: '23-KA-9101',
+    type: "cognite_annotation",
+    subtype: "pnid_annotation",
+    description: "23-KA-9101",
     metadata: {
       CDF_ANNOTATION_box:
         '{"xMax":0.556137875428341,"xMin":0.5055432372505543,"yMax":0.8469213226909921,"yMin":0.8358038768529077}',
-      CDF_ANNOTATION_file_external_id: 'PH-ME-P-0153-001.pdf',
-      CDF_ANNOTATION_resource_external_id: '3047932288982463',
-      CDF_ANNOTATION_resource_type: 'asset',
-      CDF_ANNOTATION_status: 'unhandled',
-      CDF_ANNOTATION_version: '5',
+      CDF_ANNOTATION_file_external_id: "PH-ME-P-0153-001.pdf",
+      CDF_ANNOTATION_resource_external_id: "3047932288982463",
+      CDF_ANNOTATION_resource_type: "asset",
+      CDF_ANNOTATION_status: "unhandled",
+      CDF_ANNOTATION_version: "5",
     },
-    source: 'job:3425030520931466',
+    source: "job:3425030520931466",
     id: 8373211813941993,
     lastUpdatedTime: 1597233855648,
     createdTime: 1597233855648,
   },
   {
-    type: 'cognite_annotation',
-    subtype: 'pnid_annotation',
+    type: "cognite_annotation",
+    subtype: "pnid_annotation",
     description: '"COUNTING OF ""BALLAST/BILGE SYSTEMS"" SPARE PARTS',
     metadata: {
       CDF_ANNOTATION_box:
         '{"xMin":0.2639194530131101,"yMin":0.4329073482428115,"xMax":0.296677040872535,"yMax":0.48083067092651754}',
-      CDF_ANNOTATION_file_external_id: 'PH-ME-P-0153-001.pdf',
-      CDF_ANNOTATION_resource_external_id: '3851005878284980',
-      CDF_ANNOTATION_resource_type: 'asset',
-      CDF_ANNOTATION_status: 'verified',
-      CDF_ANNOTATION_version: '5',
-      CDF_ANNOTATION_page: '1',
+      CDF_ANNOTATION_file_external_id: "PH-ME-P-0153-001.pdf",
+      CDF_ANNOTATION_resource_external_id: "3851005878284980",
+      CDF_ANNOTATION_resource_type: "asset",
+      CDF_ANNOTATION_status: "verified",
+      CDF_ANNOTATION_version: "5",
+      CDF_ANNOTATION_page: "1",
     },
-    source: 'email:arne.kvadsheim@cognite.com',
+    source: "email:arne.kvadsheim@cognite.com",
     id: 8578873357196321,
     lastUpdatedTime: 1598349949694,
     createdTime: 1598349949694,
   },
   {
-    type: 'cognite_annotation',
-    subtype: 'pnid_annotation',
-    description: 'david',
+    type: "cognite_annotation",
+    subtype: "pnid_annotation",
+    description: "david",
     metadata: {
       CDF_ANNOTATION_box:
         '{"xMin":0.6195874527313318,"yMin":0.5553191489361702,"xMax":0.794079836590885,"yMax":0.676595744680851}',
-      CDF_ANNOTATION_file_external_id: 'PH-ME-P-0153-001.pdf',
-      CDF_ANNOTATION_status: 'deleted',
-      CDF_ANNOTATION_version: '5',
+      CDF_ANNOTATION_file_external_id: "PH-ME-P-0153-001.pdf",
+      CDF_ANNOTATION_status: "deleted",
+      CDF_ANNOTATION_version: "5",
     },
-    source: 'email:david.liu@cognite.com',
+    source: "email:david.liu@cognite.com",
     id: 8710908745302571,
     lastUpdatedTime: 1598885035802,
     createdTime: 1598885032294,
@@ -606,7 +646,7 @@ export const orcResults = [
       yMin: 0.061193577703726146,
     },
     confidence: 1.0,
-    text: 'A',
+    text: "A",
   },
   {
     boundingBox: {
@@ -616,7 +656,7 @@ export const orcResults = [
       yMin: 0.06028476219327476,
     },
     confidence: 1.0,
-    text: 'Simple',
+    text: "Simple",
   },
   {
     boundingBox: {
@@ -626,7 +666,7 @@ export const orcResults = [
       yMin: 0.06270827022114511,
     },
     confidence: 1.0,
-    text: 'PDF',
+    text: "PDF",
   },
   {
     boundingBox: {
@@ -636,7 +676,7 @@ export const orcResults = [
       yMin: 0.0630112087246289,
     },
     confidence: 1.0,
-    text: 'File',
+    text: "File",
   },
   {
     boundingBox: {
@@ -646,7 +686,7 @@ export const orcResults = [
       yMin: 0.12117540139351711,
     },
     confidence: 1.0,
-    text: 'This',
+    text: "This",
   },
   {
     boundingBox: {
@@ -656,7 +696,7 @@ export const orcResults = [
       yMin: 0.12117540139351711,
     },
     confidence: 1.0,
-    text: 'is',
+    text: "is",
   },
   {
     boundingBox: {
@@ -666,7 +706,7 @@ export const orcResults = [
       yMin: 0.12359890942138746,
     },
     confidence: 1.0,
-    text: 'a',
+    text: "a",
   },
   {
     boundingBox: {
@@ -676,7 +716,7 @@ export const orcResults = [
       yMin: 0.12117540139351711,
     },
     confidence: 1.0,
-    text: 'small',
+    text: "small",
   },
   {
     boundingBox: {
@@ -686,7 +726,7 @@ export const orcResults = [
       yMin: 0.12117540139351711,
     },
     confidence: 1.0,
-    text: 'demonstration',
+    text: "demonstration",
   },
   {
     boundingBox: {
@@ -696,7 +736,7 @@ export const orcResults = [
       yMin: 0.12117540139351711,
     },
     confidence: 1.0,
-    text: '.pdf',
+    text: ".pdf",
   },
   {
     boundingBox: {
@@ -706,7 +746,7 @@ export const orcResults = [
       yMin: 0.12117540139351711,
     },
     confidence: 1.0,
-    text: 'file',
+    text: "file",
   },
   {
     boundingBox: {
@@ -716,7 +756,7 @@ export const orcResults = [
       yMin: 0.1260224174492578,
     },
     confidence: 1.0,
-    text: '-',
+    text: "-",
   },
   {
     boundingBox: {
@@ -726,7 +766,7 @@ export const orcResults = [
       yMin: 0.1514692517418964,
     },
     confidence: 1.0,
-    text: 'just',
+    text: "just",
   },
   {
     boundingBox: {
@@ -736,7 +776,7 @@ export const orcResults = [
       yMin: 0.1514692517418964,
     },
     confidence: 1.0,
-    text: 'for',
+    text: "for",
   },
   {
     boundingBox: {
@@ -746,7 +786,7 @@ export const orcResults = [
       yMin: 0.15389275976976674,
     },
     confidence: 1.0,
-    text: 'use',
+    text: "use",
   },
   {
     boundingBox: {
@@ -756,7 +796,7 @@ export const orcResults = [
       yMin: 0.1514692517418964,
     },
     confidence: 1.0,
-    text: 'in',
+    text: "in",
   },
   {
     boundingBox: {
@@ -766,7 +806,7 @@ export const orcResults = [
       yMin: 0.1514692517418964,
     },
     confidence: 1.0,
-    text: 'the',
+    text: "the",
   },
   {
     boundingBox: {
@@ -776,7 +816,7 @@ export const orcResults = [
       yMin: 0.1514692517418964,
     },
     confidence: 1.0,
-    text: 'Virtual',
+    text: "Virtual",
   },
   {
     boundingBox: {
@@ -786,7 +826,7 @@ export const orcResults = [
       yMin: 0.1514692517418964,
     },
     confidence: 1.0,
-    text: 'Mechanics',
+    text: "Mechanics",
   },
   {
     boundingBox: {
@@ -796,7 +836,7 @@ export const orcResults = [
       yMin: 0.1514692517418964,
     },
     confidence: 1.0,
-    text: 'tutorials.',
+    text: "tutorials.",
   },
   {
     boundingBox: {
@@ -806,7 +846,7 @@ export const orcResults = [
       yMin: 0.1514692517418964,
     },
     confidence: 1.0,
-    text: 'More',
+    text: "More",
   },
   {
     boundingBox: {
@@ -816,7 +856,7 @@ export const orcResults = [
       yMin: 0.15207512874886397,
     },
     confidence: 1.0,
-    text: 'text.',
+    text: "text.",
   },
   {
     boundingBox: {
@@ -826,7 +866,7 @@ export const orcResults = [
       yMin: 0.1514692517418964,
     },
     confidence: 1.0,
-    text: 'And',
+    text: "And",
   },
   {
     boundingBox: {
@@ -836,7 +876,7 @@ export const orcResults = [
       yMin: 0.15389275976976674,
     },
     confidence: 1.0,
-    text: 'more',
+    text: "more",
   },
   {
     boundingBox: {
@@ -846,7 +886,7 @@ export const orcResults = [
       yMin: 0.16722205392305362,
     },
     confidence: 1.0,
-    text: 'text.',
+    text: "text.",
   },
   {
     boundingBox: {
@@ -856,7 +896,7 @@ export const orcResults = [
       yMin: 0.16661617691608605,
     },
     confidence: 1.0,
-    text: 'And',
+    text: "And",
   },
   {
     boundingBox: {
@@ -866,7 +906,7 @@ export const orcResults = [
       yMin: 0.16903968494395638,
     },
     confidence: 1.0,
-    text: 'more',
+    text: "more",
   },
   {
     boundingBox: {
@@ -876,7 +916,7 @@ export const orcResults = [
       yMin: 0.16722205392305362,
     },
     confidence: 1.0,
-    text: 'text.',
+    text: "text.",
   },
   {
     boundingBox: {
@@ -886,7 +926,7 @@ export const orcResults = [
       yMin: 0.16661617691608605,
     },
     confidence: 1.0,
-    text: 'And',
+    text: "And",
   },
   {
     boundingBox: {
@@ -896,7 +936,7 @@ export const orcResults = [
       yMin: 0.16903968494395638,
     },
     confidence: 1.0,
-    text: 'more',
+    text: "more",
   },
   {
     boundingBox: {
@@ -906,7 +946,7 @@ export const orcResults = [
       yMin: 0.16722205392305362,
     },
     confidence: 1.0,
-    text: 'text.',
+    text: "text.",
   },
   {
     boundingBox: {
@@ -916,7 +956,7 @@ export const orcResults = [
       yMin: 0.16661617691608605,
     },
     confidence: 1.0,
-    text: 'And',
+    text: "And",
   },
   {
     boundingBox: {
@@ -926,7 +966,7 @@ export const orcResults = [
       yMin: 0.16903968494395638,
     },
     confidence: 1.0,
-    text: 'more',
+    text: "more",
   },
   {
     boundingBox: {
@@ -936,7 +976,7 @@ export const orcResults = [
       yMin: 0.16722205392305362,
     },
     confidence: 1.0,
-    text: 'text.',
+    text: "text.",
   },
   {
     boundingBox: {
@@ -946,7 +986,7 @@ export const orcResults = [
       yMin: 0.1966070887609815,
     },
     confidence: 1.0,
-    text: 'And',
+    text: "And",
   },
   {
     boundingBox: {
@@ -956,7 +996,7 @@ export const orcResults = [
       yMin: 0.19903059678885185,
     },
     confidence: 1.0,
-    text: 'more',
+    text: "more",
   },
   {
     boundingBox: {
@@ -966,7 +1006,7 @@ export const orcResults = [
       yMin: 0.1972129657679491,
     },
     confidence: 1.0,
-    text: 'text.',
+    text: "text.",
   },
   {
     boundingBox: {
@@ -976,7 +1016,7 @@ export const orcResults = [
       yMin: 0.1966070887609815,
     },
     confidence: 1.0,
-    text: 'And',
+    text: "And",
   },
   {
     boundingBox: {
@@ -986,7 +1026,7 @@ export const orcResults = [
       yMin: 0.19903059678885185,
     },
     confidence: 1.0,
-    text: 'more',
+    text: "more",
   },
   {
     boundingBox: {
@@ -996,7 +1036,7 @@ export const orcResults = [
       yMin: 0.1972129657679491,
     },
     confidence: 1.0,
-    text: 'text.',
+    text: "text.",
   },
   {
     boundingBox: {
@@ -1006,7 +1046,7 @@ export const orcResults = [
       yMin: 0.1966070887609815,
     },
     confidence: 1.0,
-    text: 'And',
+    text: "And",
   },
   {
     boundingBox: {
@@ -1016,7 +1056,7 @@ export const orcResults = [
       yMin: 0.19903059678885185,
     },
     confidence: 1.0,
-    text: 'more',
+    text: "more",
   },
   {
     boundingBox: {
@@ -1026,7 +1066,7 @@ export const orcResults = [
       yMin: 0.1972129657679491,
     },
     confidence: 1.0,
-    text: 'text.',
+    text: "text.",
   },
   {
     boundingBox: {
@@ -1036,7 +1076,7 @@ export const orcResults = [
       yMin: 0.1966070887609815,
     },
     confidence: 1.0,
-    text: 'And',
+    text: "And",
   },
   {
     boundingBox: {
@@ -1046,7 +1086,7 @@ export const orcResults = [
       yMin: 0.19903059678885185,
     },
     confidence: 1.0,
-    text: 'more',
+    text: "more",
   },
   {
     boundingBox: {
@@ -1056,7 +1096,7 @@ export const orcResults = [
       yMin: 0.1972129657679491,
     },
     confidence: 1.0,
-    text: 'text.',
+    text: "text.",
   },
   {
     boundingBox: {
@@ -1066,7 +1106,7 @@ export const orcResults = [
       yMin: 0.1966070887609815,
     },
     confidence: 1.0,
-    text: 'And',
+    text: "And",
   },
   {
     boundingBox: {
@@ -1076,7 +1116,7 @@ export const orcResults = [
       yMin: 0.19903059678885185,
     },
     confidence: 1.0,
-    text: 'more',
+    text: "more",
   },
   {
     boundingBox: {
@@ -1086,7 +1126,7 @@ export const orcResults = [
       yMin: 0.21235989094213875,
     },
     confidence: 1.0,
-    text: 'text.',
+    text: "text.",
   },
   {
     boundingBox: {
@@ -1096,7 +1136,7 @@ export const orcResults = [
       yMin: 0.21175401393517115,
     },
     confidence: 1.0,
-    text: 'And',
+    text: "And",
   },
   {
     boundingBox: {
@@ -1106,7 +1146,7 @@ export const orcResults = [
       yMin: 0.2138745834595577,
     },
     confidence: 1.0,
-    text: 'more',
+    text: "more",
   },
   {
     boundingBox: {
@@ -1116,7 +1156,7 @@ export const orcResults = [
       yMin: 0.21235989094213875,
     },
     confidence: 1.0,
-    text: 'text.',
+    text: "text.",
   },
   {
     boundingBox: {
@@ -1126,7 +1166,7 @@ export const orcResults = [
       yMin: 0.21175401393517115,
     },
     confidence: 1.0,
-    text: 'Boring,',
+    text: "Boring,",
   },
   {
     boundingBox: {
@@ -1136,7 +1176,7 @@ export const orcResults = [
       yMin: 0.2141775219630415,
     },
     confidence: 1.0,
-    text: 'zzzzz.',
+    text: "zzzzz.",
   },
   {
     boundingBox: {
@@ -1146,7 +1186,7 @@ export const orcResults = [
       yMin: 0.21175401393517115,
     },
     confidence: 1.0,
-    text: 'And',
+    text: "And",
   },
   {
     boundingBox: {
@@ -1156,7 +1196,7 @@ export const orcResults = [
       yMin: 0.2138745834595577,
     },
     confidence: 1.0,
-    text: 'more',
+    text: "more",
   },
   {
     boundingBox: {
@@ -1166,7 +1206,7 @@ export const orcResults = [
       yMin: 0.21235989094213875,
     },
     confidence: 1.0,
-    text: 'text.',
+    text: "text.",
   },
   {
     boundingBox: {
@@ -1176,7 +1216,7 @@ export const orcResults = [
       yMin: 0.21175401393517115,
     },
     confidence: 1.0,
-    text: 'And',
+    text: "And",
   },
   {
     boundingBox: {
@@ -1186,7 +1226,7 @@ export const orcResults = [
       yMin: 0.2138745834595577,
     },
     confidence: 1.0,
-    text: 'more',
+    text: "more",
   },
   {
     boundingBox: {
@@ -1196,7 +1236,7 @@ export const orcResults = [
       yMin: 0.21235989094213875,
     },
     confidence: 1.0,
-    text: 'text.',
+    text: "text.",
   },
   {
     boundingBox: {
@@ -1206,7 +1246,7 @@ export const orcResults = [
       yMin: 0.21175401393517115,
     },
     confidence: 1.0,
-    text: 'And',
+    text: "And",
   },
   {
     boundingBox: {
@@ -1216,7 +1256,7 @@ export const orcResults = [
       yMin: 0.22902150863374734,
     },
     confidence: 1.0,
-    text: 'more',
+    text: "more",
   },
   {
     boundingBox: {
@@ -1226,7 +1266,7 @@ export const orcResults = [
       yMin: 0.2275068161163284,
     },
     confidence: 1.0,
-    text: 'text.',
+    text: "text.",
   },
   {
     boundingBox: {
@@ -1236,7 +1276,7 @@ export const orcResults = [
       yMin: 0.2269009391093608,
     },
     confidence: 1.0,
-    text: 'And',
+    text: "And",
   },
   {
     boundingBox: {
@@ -1246,7 +1286,7 @@ export const orcResults = [
       yMin: 0.22902150863374734,
     },
     confidence: 1.0,
-    text: 'more',
+    text: "more",
   },
   {
     boundingBox: {
@@ -1256,7 +1296,7 @@ export const orcResults = [
       yMin: 0.2275068161163284,
     },
     confidence: 1.0,
-    text: 'text.',
+    text: "text.",
   },
   {
     boundingBox: {
@@ -1266,7 +1306,7 @@ export const orcResults = [
       yMin: 0.2269009391093608,
     },
     confidence: 1.0,
-    text: 'And',
+    text: "And",
   },
   {
     boundingBox: {
@@ -1276,7 +1316,7 @@ export const orcResults = [
       yMin: 0.22902150863374734,
     },
     confidence: 1.0,
-    text: 'more',
+    text: "more",
   },
   {
     boundingBox: {
@@ -1286,7 +1326,7 @@ export const orcResults = [
       yMin: 0.2275068161163284,
     },
     confidence: 1.0,
-    text: 'text.',
+    text: "text.",
   },
   {
     boundingBox: {
@@ -1296,7 +1336,7 @@ export const orcResults = [
       yMin: 0.2269009391093608,
     },
     confidence: 1.0,
-    text: 'And',
+    text: "And",
   },
   {
     boundingBox: {
@@ -1306,7 +1346,7 @@ export const orcResults = [
       yMin: 0.22902150863374734,
     },
     confidence: 1.0,
-    text: 'more',
+    text: "more",
   },
   {
     boundingBox: {
@@ -1316,7 +1356,7 @@ export const orcResults = [
       yMin: 0.2275068161163284,
     },
     confidence: 1.0,
-    text: 'text.',
+    text: "text.",
   },
   {
     boundingBox: {
@@ -1326,7 +1366,7 @@ export const orcResults = [
       yMin: 0.2269009391093608,
     },
     confidence: 1.0,
-    text: 'And',
+    text: "And",
   },
   {
     boundingBox: {
@@ -1336,7 +1376,7 @@ export const orcResults = [
       yMin: 0.22902150863374734,
     },
     confidence: 1.0,
-    text: 'more',
+    text: "more",
   },
   {
     boundingBox: {
@@ -1346,7 +1386,7 @@ export const orcResults = [
       yMin: 0.2275068161163284,
     },
     confidence: 1.0,
-    text: 'text.',
+    text: "text.",
   },
   {
     boundingBox: {
@@ -1356,7 +1396,7 @@ export const orcResults = [
       yMin: 0.24204786428355043,
     },
     confidence: 1.0,
-    text: 'And',
+    text: "And",
   },
   {
     boundingBox: {
@@ -1366,7 +1406,7 @@ export const orcResults = [
       yMin: 0.24447137231142077,
     },
     confidence: 1.0,
-    text: 'more',
+    text: "more",
   },
   {
     boundingBox: {
@@ -1376,7 +1416,7 @@ export const orcResults = [
       yMin: 0.24265374129051803,
     },
     confidence: 1.0,
-    text: 'text.',
+    text: "text.",
   },
   {
     boundingBox: {
@@ -1386,7 +1426,7 @@ export const orcResults = [
       yMin: 0.24204786428355043,
     },
     confidence: 1.0,
-    text: 'And',
+    text: "And",
   },
   {
     boundingBox: {
@@ -1396,7 +1436,7 @@ export const orcResults = [
       yMin: 0.24447137231142077,
     },
     confidence: 1.0,
-    text: 'more',
+    text: "more",
   },
   {
     boundingBox: {
@@ -1406,7 +1446,7 @@ export const orcResults = [
       yMin: 0.24265374129051803,
     },
     confidence: 1.0,
-    text: 'text.',
+    text: "text.",
   },
   {
     boundingBox: {
@@ -1416,7 +1456,7 @@ export const orcResults = [
       yMin: 0.2720387761284459,
     },
     confidence: 1.0,
-    text: 'And',
+    text: "And",
   },
   {
     boundingBox: {
@@ -1426,7 +1466,7 @@ export const orcResults = [
       yMin: 0.2744622841563163,
     },
     confidence: 1.0,
-    text: 'more',
+    text: "more",
   },
   {
     boundingBox: {
@@ -1436,7 +1476,7 @@ export const orcResults = [
       yMin: 0.27264465313541353,
     },
     confidence: 1.0,
-    text: 'text.',
+    text: "text.",
   },
   {
     boundingBox: {
@@ -1446,7 +1486,7 @@ export const orcResults = [
       yMin: 0.2720387761284459,
     },
     confidence: 1.0,
-    text: 'And',
+    text: "And",
   },
   {
     boundingBox: {
@@ -1456,7 +1496,7 @@ export const orcResults = [
       yMin: 0.2744622841563163,
     },
     confidence: 1.0,
-    text: 'more',
+    text: "more",
   },
   {
     boundingBox: {
@@ -1466,7 +1506,7 @@ export const orcResults = [
       yMin: 0.27264465313541353,
     },
     confidence: 1.0,
-    text: 'text.',
+    text: "text.",
   },
   {
     boundingBox: {
@@ -1476,7 +1516,7 @@ export const orcResults = [
       yMin: 0.2720387761284459,
     },
     confidence: 1.0,
-    text: 'And',
+    text: "And",
   },
   {
     boundingBox: {
@@ -1486,7 +1526,7 @@ export const orcResults = [
       yMin: 0.2744622841563163,
     },
     confidence: 1.0,
-    text: 'more',
+    text: "more",
   },
   {
     boundingBox: {
@@ -1496,7 +1536,7 @@ export const orcResults = [
       yMin: 0.27264465313541353,
     },
     confidence: 1.0,
-    text: 'text.',
+    text: "text.",
   },
   {
     boundingBox: {
@@ -1506,7 +1546,7 @@ export const orcResults = [
       yMin: 0.2720387761284459,
     },
     confidence: 1.0,
-    text: 'And',
+    text: "And",
   },
   {
     boundingBox: {
@@ -1516,7 +1556,7 @@ export const orcResults = [
       yMin: 0.2744622841563163,
     },
     confidence: 1.0,
-    text: 'more',
+    text: "more",
   },
   {
     boundingBox: {
@@ -1526,7 +1566,7 @@ export const orcResults = [
       yMin: 0.27264465313541353,
     },
     confidence: 1.0,
-    text: 'text.',
+    text: "text.",
   },
   {
     boundingBox: {
@@ -1536,7 +1576,7 @@ export const orcResults = [
       yMin: 0.2720387761284459,
     },
     confidence: 1.0,
-    text: 'And',
+    text: "And",
   },
   {
     boundingBox: {
@@ -1546,7 +1586,7 @@ export const orcResults = [
       yMin: 0.2744622841563163,
     },
     confidence: 1.0,
-    text: 'more',
+    text: "more",
   },
   {
     boundingBox: {
@@ -1556,7 +1596,7 @@ export const orcResults = [
       yMin: 0.28779157830960317,
     },
     confidence: 1.0,
-    text: 'text.',
+    text: "text.",
   },
   {
     boundingBox: {
@@ -1566,7 +1606,7 @@ export const orcResults = [
       yMin: 0.28718570130263554,
     },
     confidence: 1.0,
-    text: 'And',
+    text: "And",
   },
   {
     boundingBox: {
@@ -1576,7 +1616,7 @@ export const orcResults = [
       yMin: 0.28960920933050593,
     },
     confidence: 1.0,
-    text: 'more',
+    text: "more",
   },
   {
     boundingBox: {
@@ -1586,7 +1626,7 @@ export const orcResults = [
       yMin: 0.28779157830960317,
     },
     confidence: 1.0,
-    text: 'text.',
+    text: "text.",
   },
   {
     boundingBox: {
@@ -1596,7 +1636,7 @@ export const orcResults = [
       yMin: 0.28718570130263554,
     },
     confidence: 1.0,
-    text: 'And',
+    text: "And",
   },
   {
     boundingBox: {
@@ -1606,7 +1646,7 @@ export const orcResults = [
       yMin: 0.28960920933050593,
     },
     confidence: 1.0,
-    text: 'more',
+    text: "more",
   },
   {
     boundingBox: {
@@ -1616,7 +1656,7 @@ export const orcResults = [
       yMin: 0.28779157830960317,
     },
     confidence: 1.0,
-    text: 'text.',
+    text: "text.",
   },
   {
     boundingBox: {
@@ -1626,7 +1666,7 @@ export const orcResults = [
       yMin: 0.28718570130263554,
     },
     confidence: 1.0,
-    text: 'Even',
+    text: "Even",
   },
   {
     boundingBox: {
@@ -1636,7 +1676,7 @@ export const orcResults = [
       yMin: 0.28960920933050593,
     },
     confidence: 1.0,
-    text: 'more.',
+    text: "more.",
   },
   {
     boundingBox: {
@@ -1646,7 +1686,7 @@ export const orcResults = [
       yMin: 0.28688276279915176,
     },
     confidence: 1.0,
-    text: 'Continued',
+    text: "Continued",
   },
   {
     boundingBox: {
@@ -1656,7 +1696,7 @@ export const orcResults = [
       yMin: 0.28960920933050593,
     },
     confidence: 1.0,
-    text: 'on',
+    text: "on",
   },
   {
     boundingBox: {
@@ -1666,7 +1706,7 @@ export const orcResults = [
       yMin: 0.28960920933050593,
     },
     confidence: 1.0,
-    text: 'page',
+    text: "page",
   },
   {
     boundingBox: {
@@ -1676,7 +1716,7 @@ export const orcResults = [
       yMin: 0.2874886398061194,
     },
     confidence: 1.0,
-    text: '2',
+    text: "2",
   },
   {
     boundingBox: {
@@ -1686,6 +1726,6 @@ export const orcResults = [
       yMin: 0.2950621023932142,
     },
     confidence: 1.0,
-    text: '...',
+    text: "...",
   },
 ];

--- a/stories/resources.tsx
+++ b/stories/resources.tsx
@@ -5,7 +5,7 @@ export const twoAnnotationsResponse = [
     description: "This is a customizable annotation!",
     metadata: {
       CDF_ANNOTATION_box:
-        '{"xMin":0.28109384469584436,"yMin":0.15310077519379847,"xMax":0.3489239209872729,"yMax":0.22868217054263568}',
+        '{"xMin":0.28109384469584436,"yMin":0.15310077519379847,"xMax":0.5489239209872729,"yMax":0.32868217054263568}',
       CDF_ANNOTATION_file_external_id: "dummy.pdf",
       CDF_ANNOTATION_resource_external_id: "dummyfile",
       CDF_ANNOTATION_resource_id: "1233",

--- a/stories/utils.tsx
+++ b/stories/utils.tsx
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 import { CogniteClient } from "@cognite/sdk";
-import { response, orcResults } from "./resources";
+import { response, twoAnnotationsResponse, orcResults } from "./resources";
 import { FileViewerContextObserverPublicProps } from "../src";
 import randomId from "../src/utils/randomId";
 
@@ -21,6 +21,23 @@ export const imgFile = {
   name: "Random File",
   mimeType: "image/png",
 };
+
+export const imgSdkTwoAnnotations = ({
+  events: {
+    list: (..._: any[]) => ({
+      autoPagingToArray: async () => twoAnnotationsResponse,
+    }),
+    update: async (...annotations: any[]) =>
+      annotations.map((el) => el.annotation),
+    create: async (...annotations: any[]) =>
+      annotations.map((el) => ({ ...el, id: randomId() })),
+  },
+  post: async () => ({ data: { items: [{ annotations: orcResults }] } }),
+  files: {
+    retrieve: async () => [imgFile],
+    getDownloadUrls: async () => [{ downloadUrl: "//unsplash.it/800/400" }],
+  },
+} as unknown) as CogniteClient;
 
 export const imgSdk = ({
   events: {


### PR DESCRIPTION
Relevant ticket: [click!](https://cognitedata.atlassian.net/browse/SPLN-156)

This PR allows to control what the annotation boxes look like from the outside of the `<CogniteFileViewer>` component. More details on what this works like is in relevant story in Storybook.

@peternic tagging you because this blocks you right now afaik - for now this allows to customize what the annotation looks like only via the `annotation` object, I'm working on having a function that makes it a bit easier though