### PR TITLE
fix: properly positioning item previews

### DIFF
--- a/src/ReactPictureAnnotation.tsx
+++ b/src/ReactPictureAnnotation.tsx
@@ -489,7 +489,7 @@ export class ReactPictureAnnotation extends React.Component<
             // ...(leftOfMiddle?{paddingLeft: margin}:{paddingRight:margin}),
             ...(topOfMiddle
               ? { top: y + height + strokeWidth }
-              : { bottom: -y + strokeWidth }),
+              : { bottom: -y + containerHeight + strokeWidth }),
             ...(topOfMiddle
               ? { paddingTop: margin }
               : { paddingBottom: margin }),

--- a/stories/cognite.stories.tsx
+++ b/stories/cognite.stories.tsx
@@ -353,6 +353,28 @@ export const Playground = () => {
       hoverable={boolean("Hoverable", false)}
       pagination={select("Pagination", ["small", "normal", false], "normal")}
       onAnnotationSelected={action("onAnnotationSelected")}
+      renderItemPreview={() => (
+        <div
+          style={{
+            backgroundColor: "white",
+            border: "1px solid black",
+            padding: "5px",
+          }}
+        >
+          <ul style={{ margin: 0, padding: 0, listStyleType: "none" }}>
+            <li>test</li>
+            <li>test</li>
+            <li>test</li>
+            <li>test</li>
+            <li>test</li>
+            <li>test</li>
+            <li>test</li>
+            <li>test</li>
+            <li>test</li>
+            <li>test</li>
+          </ul>
+        </div>
+      )}
     />
   );
 };


### PR DESCRIPTION
Annotation preview boxes no longer randomly disappear (more accurately, they aren't ejected out of screen anymore)