### PR TITLE
fix: boxes now load instantly after adding them

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "@cognite/cogs.js": "^2.0.3",
     "@cognite/sdk": "^3.1.1",
     "@storybook/addon-knobs": "^6.0.22",
+    "@types/lodash": "^4.14.165",
     "parse-color": "^1.0.0",
     "pdf-lib": "^1.12.0",
     "pdfjs-dist": "2.6.347",

--- a/src/ReactPictureAnnotation.tsx
+++ b/src/ReactPictureAnnotation.tsx
@@ -170,13 +170,21 @@ export class ReactPictureAnnotation extends React.Component<
   public componentDidUpdate = async (
     prevProps: IReactPictureAnnotationProps
   ) => {
-    const { width, height, image, pdf, page, annotationData } = this.props;
+    const {
+      width,
+      height,
+      image,
+      pdf,
+      page,
+      renderArrowPreview,
+      annotationData,
+    } = this.props;
     if (prevProps.width !== width || prevProps.height !== height) {
       this.setCanvasDPI();
       this.onShapeChange();
       this.onImageChange();
     }
-    if (!isEqual(prevProps.annotationData, annotationData)) {
+    if (!isEqual(prevProps.renderArrowPreview, renderArrowPreview)) {
       this.loadArrowPreviews();
     }
     if (prevProps.pdf !== pdf) {
@@ -292,18 +300,24 @@ export class ReactPictureAnnotation extends React.Component<
   };
 
   public loadArrowPreviews = () => {
-    const newArrowPreviewPositions = [];
-    for (const annotation in this.props.annotationData) {
-      newArrowPreviewPositions[this.props.annotationData[annotation].id] = {
-        x: 0,
-        y: 0,
+    const newArrowPreviewPositions = {};
+    const annotations = this.props.annotationData;
+    for (const annotation in annotations) {
+      const oldAnnotationPosition = this.state.arrowPreviewPositions[
+        annotations[annotation]?.id
+      ];
+      newArrowPreviewPositions[annotations[annotation].id] = {
+        x: oldAnnotationPosition?.x ?? 0,
+        y: oldAnnotationPosition?.y ?? 0,
       };
     }
-    this.setState({
-      annotationsLoaded: true,
-      arrowPreviewPositions: newArrowPreviewPositions,
-    });
-    this.onShapeChange();
+    this.setState(
+      {
+        annotationsLoaded: true,
+        arrowPreviewPositions: newArrowPreviewPositions,
+      },
+      this.onShapeChange
+    );
   };
 
   public updateBoxPosition = (id: number, offsetX: number, offsetY: number) => {
@@ -345,12 +359,12 @@ export class ReactPictureAnnotation extends React.Component<
       hideArrowPreview,
     } = this.state;
 
-    const showArrowPreview = () =>
+    const showArrowPreview = () => {
       // @ts-ignore
-      annotationData?.map((annotation: any) => {
+      return annotationData?.map((annotation: any) => {
         const position: any = arrowPreviewPositions[annotation.id];
         const arrowBox = renderArrowPreview(annotation);
-        if (position && arrowBox) {
+        if (position && position.x !== 0 && position.y !== 0 && arrowBox) {
           return (
             // @ts-ignore
             <StyledArrowBox
@@ -363,6 +377,7 @@ export class ReactPictureAnnotation extends React.Component<
           );
         }
       });
+    };
 
     const showPreview = (selectedItem: any) => (
       <div
@@ -430,6 +445,8 @@ export class ReactPictureAnnotation extends React.Component<
         return;
       }
 
+      let updatedArrowPreviewPositions: any = this.state.arrowPreviewPositions;
+
       for (const item of this.shapes) {
         const annotation = item.getAnnotationData();
         const itemId = annotation.id;
@@ -443,21 +460,18 @@ export class ReactPictureAnnotation extends React.Component<
           scale,
           false
         );
-
         if (
           this.props.renderArrowPreview &&
           this.props.renderArrowPreview(annotation)
         ) {
-          this.setState({
-            arrowPreviewPositions: {
-              ...this.state.arrowPreviewPositions,
-              [itemId]: {
-                ...this.state.arrowPreviewPositions[itemId],
-                x,
-                y,
-              },
+          updatedArrowPreviewPositions = {
+            ...updatedArrowPreviewPositions,
+            [itemId]: {
+              ...updatedArrowPreviewPositions[itemId],
+              x,
+              y,
             },
-          });
+          };
         }
 
         if (isSelected) {
@@ -509,13 +523,13 @@ export class ReactPictureAnnotation extends React.Component<
           this.setState({ showInput: true, inputPosition });
         }
       }
-
       if (!hasSelectedItem) {
         this.setState({
           showInput: false,
           inputComment: "",
         });
       }
+      this.setState({ arrowPreviewPositions: updatedArrowPreviewPositions });
     }
 
     this.currentAnnotationData = this.shapes.map((item) =>

--- a/src/ReactPictureAnnotation.tsx
+++ b/src/ReactPictureAnnotation.tsx
@@ -2,6 +2,7 @@ import React, { MouseEventHandler, TouchEventHandler } from "react";
 import * as pdfjs from "pdfjs-dist";
 import { PDFDocument, rgb, PDFPage, degrees } from "pdf-lib";
 import parseColor from "parse-color";
+import { isEqual } from "lodash";
 import { IAnnotation } from "./Annotation";
 import { IAnnotationState } from "./annotation/AnnotationState";
 import { DefaultAnnotationState } from "./annotation/DefaultAnnotationState";
@@ -169,11 +170,14 @@ export class ReactPictureAnnotation extends React.Component<
   public componentDidUpdate = async (
     prevProps: IReactPictureAnnotationProps
   ) => {
-    const { width, height, image, pdf, page } = this.props;
+    const { width, height, image, pdf, page, annotationData } = this.props;
     if (prevProps.width !== width || prevProps.height !== height) {
       this.setCanvasDPI();
       this.onShapeChange();
       this.onImageChange();
+    }
+    if (!isEqual(prevProps.annotationData, annotationData)) {
+      this.loadArrowPreviews();
     }
     if (prevProps.pdf !== pdf) {
       if (pdf) {
@@ -212,8 +216,8 @@ export class ReactPictureAnnotation extends React.Component<
     this.syncAnnotationData();
     this.syncSelectedId();
     if (
-      this.props.annotationData &&
-      this.props.annotationData.length > 0 &&
+      annotationData &&
+      annotationData.length > 0 &&
       !this.state.annotationsLoaded
     )
       this.loadArrowPreviews();

--- a/src/ReactPictureAnnotation.tsx
+++ b/src/ReactPictureAnnotation.tsx
@@ -489,7 +489,7 @@ export class ReactPictureAnnotation extends React.Component<
             // ...(leftOfMiddle?{paddingLeft: margin}:{paddingRight:margin}),
             ...(topOfMiddle
               ? { top: y + height + strokeWidth }
-              : { bottom: -y + strokeWidth }),
+              : { bottom: -y + containerHeight + strokeWidth }),
             ...(topOfMiddle
               ? { paddingTop: margin }
               : { paddingBottom: margin }),

--- a/stories/cognite.stories.tsx
+++ b/stories/cognite.stories.tsx
@@ -343,6 +343,10 @@ export const BoxAndArrows = () => {
 };
 export const Playground = () => {
   const [annotations, setAnnotations] = useState<CogniteAnnotation[]>([]);
+  const [
+    annotationIdsWithArrowBoxes,
+    setAnnotationIdsWithArrowBoxes,
+  ] = useState([] as number[]);
   useEffect(() => {
     (async () => {
       const rawAnnotations = await listAnnotationsForFile(imgSdk, imgFile);
@@ -350,15 +354,32 @@ export const Playground = () => {
     })();
   }, []);
   const generateArrowPreview = () => {
-    const newAnnotations = annotations.map((annotation: any) => {
-      if (annotation.id % 2 === 0)
-        return {
-          ...annotation,
-          boxPreview: true,
-        };
-      else return annotation;
+    const randomIndex = Math.floor(Math.random() * annotations.length);
+    const randomAnnotation = annotations[randomIndex];
+    if (
+      randomAnnotation &&
+      !annotationIdsWithArrowBoxes.includes(randomAnnotation.id)
+    ) {
+      setAnnotationIdsWithArrowBoxes([
+        ...annotationIdsWithArrowBoxes,
+        randomAnnotation.id,
+      ]);
+    }
+  };
+
+  const renderArrowPreview = (annotation: any) => {
+    const hasPreview = annotationIdsWithArrowBoxes.find((annotationId: any) => {
+      if (typeof annotation.id === "string")
+        return parseInt(annotation.id, 10) === annotationId;
+      else return annotation.id === annotationId;
     });
-    setAnnotations(newAnnotations);
+    if (hasPreview) {
+      return (
+        <div style={{ padding: "5px", backgroundColor: "red" }}>
+          {annotation.id}
+        </div>
+      );
+    } else return undefined;
   };
 
   return (
@@ -374,22 +395,7 @@ export const Playground = () => {
         hideLabel={boolean("Hide Label", false)}
         hoverable={boolean("Hoverable", false)}
         pagination={select("Pagination", ["small", "normal", false], "normal")}
-        renderArrowPreview={(annotation: any) => {
-          if (annotation.boxPreview) {
-            return (
-              <div
-                style={{
-                  padding: "5px",
-                  backgroundColor: "black",
-                  color: "white",
-                }}
-              >
-                test
-              </div>
-            );
-          }
-          return undefined;
-        }}
+        renderArrowPreview={renderArrowPreview}
         renderItemPreview={() => (
           <div
             style={{

--- a/stories/cognite.stories.tsx
+++ b/stories/cognite.stories.tsx
@@ -342,39 +342,78 @@ export const BoxAndArrows = () => {
   );
 };
 export const Playground = () => {
+  const [annotations, setAnnotations] = useState<CogniteAnnotation[]>([]);
+  useEffect(() => {
+    (async () => {
+      const rawAnnotations = await listAnnotationsForFile(imgSdk, imgFile);
+      setAnnotations(rawAnnotations);
+    })();
+  }, []);
+  const generateArrowPreview = () => {
+    const newAnnotations = annotations.map((annotation: any) => {
+      if (annotation.id % 2 === 0)
+        return {
+          ...annotation,
+          boxPreview: true,
+        };
+      else return annotation;
+    });
+    setAnnotations(newAnnotations);
+  };
+
   return (
-    <CogniteFileViewer
-      sdk={pdfSdk}
-      file={pdfFile}
-      editable={boolean("Editable", false)}
-      creatable={boolean("Creatable", false)}
-      hideControls={boolean("Hide Controls", false)}
-      hideLabel={boolean("Hide Label", false)}
-      hoverable={boolean("Hoverable", false)}
-      pagination={select("Pagination", ["small", "normal", false], "normal")}
-      onAnnotationSelected={action("onAnnotationSelected")}
-      renderItemPreview={() => (
-        <div
-          style={{
-            backgroundColor: "white",
-            border: "1px solid black",
-            padding: "5px",
-          }}
-        >
-          <ul style={{ margin: 0, padding: 0, listStyleType: "none" }}>
-            <li>test</li>
-            <li>test</li>
-            <li>test</li>
-            <li>test</li>
-            <li>test</li>
-            <li>test</li>
-            <li>test</li>
-            <li>test</li>
-            <li>test</li>
-            <li>test</li>
-          </ul>
-        </div>
-      )}
-    />
+    <>
+      <Button onClick={generateArrowPreview}>Generate boxes</Button>
+      <CogniteFileViewer
+        sdk={imgSdk}
+        file={imgFile}
+        annotations={annotations}
+        editable={boolean("Editable", false)}
+        creatable={boolean("Creatable", false)}
+        hideControls={boolean("Hide Controls", false)}
+        hideLabel={boolean("Hide Label", false)}
+        hoverable={boolean("Hoverable", false)}
+        pagination={select("Pagination", ["small", "normal", false], "normal")}
+        renderArrowPreview={(annotation: any) => {
+          if (annotation.boxPreview) {
+            return (
+              <div
+                style={{
+                  padding: "5px",
+                  backgroundColor: "black",
+                  color: "white",
+                }}
+              >
+                test
+              </div>
+            );
+          }
+          return undefined;
+        }}
+        renderItemPreview={() => (
+          <div
+            style={{
+              backgroundColor: "white",
+              color: "black",
+              border: "1px solid black",
+              padding: "5px",
+            }}
+          >
+            <ul style={{ margin: 0, padding: 0, listStyleType: "none" }}>
+              <li>test</li>
+              <li>test</li>
+              <li>test</li>
+              <li>test</li>
+              <li>test</li>
+              <li>test</li>
+              <li>test</li>
+              <li>test</li>
+              <li>test</li>
+              <li>test</li>
+            </ul>
+          </div>
+        )}
+      />
+    </>
   );
 };

--- a/stories/cognite.stories.tsx
+++ b/stories/cognite.stories.tsx
@@ -353,6 +353,28 @@ export const Playground = () => {
       hoverable={boolean("Hoverable", false)}
       pagination={select("Pagination", ["small", "normal", false], "normal")}
       onAnnotationSelected={action("onAnnotationSelected")}
+      renderItemPreview={() => (
+        <div
+          style={{
+            backgroundColor: "white",
+            border: "1px solid black",
+            padding: "5px",
+          }}
+        >
+          <ul style={{ margin: 0, padding: 0, listStyleType: "none" }}>
+            <li>test</li>
+            <li>test</li>
+            <li>test</li>
+            <li>test</li>
+            <li>test</li>
+            <li>test</li>
+            <li>test</li>
+            <li>test</li>
+            <li>test</li>
+            <li>test</li>
+          </ul>
+        </div>
+      )}
     />
   );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3262,6 +3262,11 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.6.tgz#f4c7ec43e81b319a9815115031709f26987891f0"
   integrity sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==
 
+"@types/lodash@^4.14.165":
+  version "4.14.165"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.165.tgz#74d55d947452e2de0742bad65270433b63a8c30f"
+  integrity sha512-tjSSOTHhI5mCHTy/OOXYIhi2Wt1qcbHmuXD1Ha7q70CgI/I71afO4XtLb/cVexki1oVYchpul/TOuu3Arcdxrg==
+
 "@types/markdown-to-jsx@^6.11.0":
   version "6.11.3"
   resolved "https://registry.yarnpkg.com/@types/markdown-to-jsx/-/markdown-to-jsx-6.11.3.tgz#cdd1619308fecbc8be7e6a26f3751260249b020e"


### PR DESCRIPTION
Previously when you dynamically added a box with arrow, it didn't appear instantly, but only after moving the P&ID or clicking on it.

Now it appears instantly, although the logic of adding them is a bit different - it needs to include store in the repo using the CogniteFileViewer. Story `Playground` updated accordingly to showcase how it works.