### PR TITLE
fix: arrow box preview passable options

### DIFF
--- a/src/ArrowBox.tsx
+++ b/src/ArrowBox.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import styled from "styled-components";
 import { ArcherContainer, ArcherElement } from "react-archer";
+import { ArrowPreviewOptions } from "./Cognite/FileViewerUtils";
 
 interface PointProps {
   position: any;
@@ -14,6 +15,7 @@ interface ArrowBoxProps extends PointProps, ArrowBoxEvents {
   annotation: any;
   renderedArrowWithBox: any;
   updateBoxPosition: any;
+  arrowPreviewOptions?: ArrowPreviewOptions;
 }
 
 const SourcePoint = styled.div.attrs((props: PointProps) => ({
@@ -53,10 +55,10 @@ export default class ArrowBox extends React.Component<ArrowBoxProps> {
     dragged: false,
     x: this.props.position.x,
     y: this.props.position.y,
-    baseOffsetX: -20,
-    baseOffsetY: -40,
     offsetX: this.props.position.offsetX ?? 0,
     offsetY: this.props.position.offsetY ?? 0,
+    baseOffsetX: this.props.arrowPreviewOptions?.baseOffset?.x ?? -20,
+    baseOffsetY: this.props.arrowPreviewOptions?.baseOffset?.y ?? -40,
   };
 
   private onDragStart = (event: React.DragEvent<HTMLDivElement>): void => {

--- a/src/Cognite/FileViewer.tsx
+++ b/src/Cognite/FileViewer.tsx
@@ -25,6 +25,7 @@ import {
   isPreviewableImage,
   retrieveOCRResults,
   TextBox,
+  ArrowPreviewOptions,
 } from "./FileViewerUtils";
 
 export type ViewerEditCallbacks = {
@@ -79,6 +80,10 @@ export type ViewerProps = {
    * Renders an always visible small draggable display connected to annotation with an arrow.
    */
   renderArrowPreview?: RenderItemPreviewFunction;
+  /**
+   * Options for the arrow preview, if it's defined.
+   */
+  arrowPreviewOptions?: ArrowPreviewOptions;
   /**
    * Override how an annotation box is drawn on top of the file
    */
@@ -137,6 +142,7 @@ export const FileViewer = ({
   renderAnnotation = convertCogniteAnnotationToIAnnotation,
   annotations: annotationsFromProps,
   renderArrowPreview, // TODO
+  arrowPreviewOptions,
 }: ViewerProps) => {
   const {
     annotations,
@@ -439,6 +445,7 @@ export const FileViewer = ({
         onLoading={(isLoading) => setLoading(isLoading)}
         renderItemPreview={renderItemPreview}
         renderArrowPreview={renderArrowPreview}
+        arrowPreviewOptions={arrowPreviewOptions}
         onPDFLoaded={async ({ pages }) => {
           setLoading(false);
           setTotalPages(pages);

--- a/src/Cognite/FileViewerUtils.tsx
+++ b/src/Cognite/FileViewerUtils.tsx
@@ -30,6 +30,13 @@ export type CustomizableCogniteAnnotation = (
   };
 };
 
+export type ArrowPreviewOptions = {
+  baseOffset?: {
+    x?: number;
+    y?: number;
+  };
+};
+
 /**
  * If there is no allowCustomAnnotations flag, those are the colors of the annotations.
  */

--- a/src/ReactPictureAnnotation.tsx
+++ b/src/ReactPictureAnnotation.tsx
@@ -3,6 +3,7 @@ import * as pdfjs from "pdfjs-dist";
 import { PDFDocument, rgb, PDFPage, degrees } from "pdf-lib";
 import parseColor from "parse-color";
 import { isEqual } from "lodash";
+import { ArrowPreviewOptions } from "./Cognite/FileViewerUtils";
 import { IAnnotation } from "./Annotation";
 import { IAnnotationState } from "./annotation/AnnotationState";
 import { DefaultAnnotationState } from "./annotation/DefaultAnnotationState";
@@ -52,6 +53,7 @@ interface IReactPictureAnnotationProps {
   creatable?: boolean;
   hoverable?: boolean;
   drawLabel: boolean;
+  arrowPreviewOptions?: ArrowPreviewOptions;
   renderArrowPreview?: any; // TODO type
   renderItemPreview?: RenderItemPreviewFunction;
   onAnnotationUpdate?: (annotation: IAnnotation) => void;
@@ -351,6 +353,7 @@ export class ReactPictureAnnotation extends React.Component<
         />
       ),
       renderArrowPreview,
+      arrowPreviewOptions,
     } = this.props;
     const {
       showInput,
@@ -371,6 +374,7 @@ export class ReactPictureAnnotation extends React.Component<
               key={`arrow-box-${annotation.id}`}
               annotation={annotation}
               position={position}
+              arrowPreviewOptions={arrowPreviewOptions}
               renderedArrowWithBox={arrowBox}
               updateBoxPosition={this.updateBoxPosition}
             />

--- a/stories/cognite.stories.mdx
+++ b/stories/cognite.stories.mdx
@@ -126,6 +126,21 @@ The `draw()` function allows you to define a canvas and draw any shape you like.
 
 ## Box and arrows
 
+You can add an additional info box to every annotation, connected to it with an arrow. To do so, use a `renderArrowPreview` prop and pass a component in it which will appear in a box connected to the annotation.
+
+There is one info box per annotation, therefore you can pass `undefined` if you do not wish for the box to appear for a particular annotation.
+
+If you want to customize arrow boxes in other fields than the connected component, you can pass an optional `arrowPreviewOptions` prop:
+
+```
+  arrowPreviewOptions: {
+    baseOffset?: { 
+      x?: number, 
+      y?: number 
+    }
+  }
+```
+
 <Canvas>
   <Story story={BoxAndArrows} />
 </Canvas>

--- a/stories/cognite.stories.tsx
+++ b/stories/cognite.stories.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useMemo } from "react";
 import { action } from "@storybook/addon-actions";
-import { boolean, select } from "@storybook/addon-knobs";
+import { boolean, number, select } from "@storybook/addon-knobs";
 import { CogniteFileViewer, ViewerEditCallbacks } from "../src";
 import {
   imgSdk,
@@ -347,6 +347,12 @@ export const BoxAndArrows = () => {
       disableAutoFetch={true}
       annotations={annotations}
       onAnnotationSelected={action("onAnnotationSelected")}
+      arrowPreviewOptions={{
+        baseOffset: {
+          x: -40,
+          y: -40,
+        },
+      }}
       renderArrowPreview={(annotation: any) => {
         if (annotation.id === "352749521886257")
           return (

--- a/stories/cognite.stories.tsx
+++ b/stories/cognite.stories.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useMemo } from "react";
 import { action } from "@storybook/addon-actions";
-import { boolean, number, select } from "@storybook/addon-knobs";
+import { boolean, select } from "@storybook/addon-knobs";
 import { CogniteFileViewer, ViewerEditCallbacks } from "../src";
 import {
   imgSdk,


### PR DESCRIPTION
You can now set up the base offset for the arrow boxes via passing a prop to `<CogniteFilePreview>`.

```jsx
<CogniteFilePreview
  ...
  arrowPreviewOptions: {
    baseOffset?: { 
      x?: number, 
      y?: number 
    }
  }
  ...
/>
```