### PR TITLE
fix: send undefined to onAnnotationSelected on deselection of annotation

### DIFF
--- a/src/Cognite/FileViewer.tsx
+++ b/src/Cognite/FileViewer.tsx
@@ -301,6 +301,9 @@ export const FileViewer = ({
   const onAnnotationSelect = (id: string | null) => {
     if (id === null) {
       setSelectedAnnotation(undefined);
+      if (onAnnotationSelected) {
+        onAnnotationSelected(undefined);
+      }
     }
     const annotation = annotations.find((el) => `${el.id}` === `${id}`);
     if (annotation) {


### PR DESCRIPTION
In isolation planning we are storing the active annotation in Redux, and when the user is clicking on something else than a annotation in the P&Id, the viewer is deselecting the annotation, but our client it not getting this message and we are not able to deselect on our end.

Maybe there is a better way I have not found, so please let mw know if so 😃 
