### PR TITLE
fix: add length check on sync annotation data

### DIFF
--- a/src/ReactPictureAnnotation.tsx
+++ b/src/ReactPictureAnnotation.tsx
@@ -884,7 +884,12 @@ export class ReactPictureAnnotation extends React.Component<IReactPictureAnnotat
         );
         this.shapes = nextShapes;
         const ids = nextShapes.map((item) => item.getAnnotationData().id);
-        this.selectedIds = this.selectedIds.filter((el) => ids.includes(el));
+        const availableSelectedIds = this.selectedIds.filter((el) =>
+          ids.includes(el)
+        );
+        if (availableSelectedIds.length !== this.selectedIds.length) {
+          this.selectedIds = availableSelectedIds;
+        }
         this.onShapeChange();
       };
 


### PR DESCRIPTION
This was causing using the setSelectedAnnotations hook to not work when setting it to an empty array.