### PR TITLE
feat: enable force-mouse-up

### DIFF
--- a/src/ReactPictureAnnotation.tsx
+++ b/src/ReactPictureAnnotation.tsx
@@ -1018,7 +1018,7 @@ export class ReactPictureAnnotation extends React.Component<IReactPictureAnnotat
       offsetX,
       offsetY
     );
-    this.currentAnnotationState.onMouseDown(event, positionX, positionY);
+
     if (
       !(creatable || editable) ||
       event.shiftKey ||
@@ -1027,6 +1027,8 @@ export class ReactPictureAnnotation extends React.Component<IReactPictureAnnotat
       const { originX, originY } = this.scaleState;
       this.startDrag = { x: offsetX, y: offsetY, originX, originY };
     }
+
+    this.currentAnnotationState.onMouseDown(event, positionX, positionY);
   };
 
   private onMouseMove: MouseEventHandler<HTMLCanvasElement> = (event) => {
@@ -1053,6 +1055,12 @@ export class ReactPictureAnnotation extends React.Component<IReactPictureAnnotat
 
   private onMouseUp: MouseEventHandler<HTMLCanvasElement> = () => {
     this.currentAnnotationState.onMouseUp();
+    this.startDrag = undefined;
+    this.setState({ hideArrowPreview: false });
+  };
+
+  public forceMouseUp = () => {
+    this.currentAnnotationState.onMouseLeave();
     this.startDrag = undefined;
     this.setState({ hideArrowPreview: false });
   };

--- a/stories/index.stories.tsx
+++ b/stories/index.stories.tsx
@@ -119,6 +119,48 @@ storiesOf("Default Viewer", module)
       </Wrapper>
     );
   })
+  .add("Force mouse up", () => {
+    const [size, setSize] = useState({
+      width: window.innerWidth - 16,
+      height: window.innerHeight - 16,
+    });
+    const containerRef = React.createRef<ReactPictureAnnotation>();
+
+    const [annotationData, setAnnotationData] = useState<
+      IAnnotation<IShapeData>[]
+    >(defaultAnnotations);
+
+    const onResize = () => {
+      setSize({
+        width: window.innerWidth - 16,
+        height: window.innerHeight - 16,
+      });
+    };
+
+    useEffect(() => {
+      window.addEventListener("resize", onResize);
+      return () => {
+        window.removeEventListener("resize", onResize);
+      };
+    }, []);
+    return (
+      <Wrapper>
+        <ReactPictureAnnotation
+          ref={containerRef}
+          renderItemPreview={() => <div />}
+          width={size.width}
+          height={size.height}
+          annotationData={annotationData}
+          onChange={(data) => setAnnotationData(data)}
+          onSelect={(e) => {
+            containerRef.current?.forceMouseUp();
+            action("onSelect")(e);
+          }}
+          image="https://unsplash.it/1200/600"
+        />
+      </Wrapper>
+    );
+  })
   .add("PDF", () => {
     const [size, setSize] = useState({
       width: window.innerWidth - 16,


### PR DESCRIPTION
When I select an annotation, I want to open a modal.
When this happens, it doesn't detect that the mouse has left the screen.
This means that when I come back, the mouse will be sticky.
Add a 'force mouse up' function that can be run on select to fix this