### PR TITLE
fix: moving annotation zoom from context to callback

### DIFF
--- a/src/Cognite/FileViewer.tsx
+++ b/src/Cognite/FileViewer.tsx
@@ -131,6 +131,10 @@ export type ViewerProps = {
    * What to display while loading. Note this is NOT displayed when `file` is not set.
    */
   loader?: React.ReactNode;
+  /**
+   * Sets the annotation that the file should zoom on
+   */
+  zoomOnAnnotation?: { annotation: CogniteAnnotation; scale?: number };
 };
 
 export const FileViewer = ({
@@ -152,6 +156,7 @@ export const FileViewer = ({
   loader,
   hideDownload = false,
   hideSearch = false,
+  zoomOnAnnotation,
   onAnnotationSelected,
   onArrowBoxMove,
   renderAnnotation = convertCogniteAnnotationToIAnnotation,
@@ -172,11 +177,9 @@ export const FileViewer = ({
     setExtractFromCanvas,
     setReset,
     setZoomIn,
-    setZoomOnAnnotation,
     setZoomOut,
     zoomIn,
     zoomOut,
-    // zoomOnAnnotation,
     reset,
     totalPages,
     setTotalPages,
@@ -280,7 +283,6 @@ export const FileViewer = ({
       setExtractFromCanvas(() => annotatorRef.current!.extractFromCanvas);
       setZoomIn(() => annotatorRef.current!.zoomIn);
       setZoomOut(() => annotatorRef.current!.zoomOut);
-      setZoomOnAnnotation(() => annotatorRef.current!.zoomOnAnnotation);
       setReset(() => annotatorRef.current!.reset);
     }
   }, [annotatorRef]);
@@ -496,6 +498,7 @@ export const FileViewer = ({
           setLoading(false);
           setTotalPages(pages);
         }}
+        zoomOnAnnotation={zoomOnAnnotation}
       />
       {totalPages > 1 && pagination && (
         <DocumentPagination

--- a/stories/cognite.stories.mdx
+++ b/stories/cognite.stories.mdx
@@ -14,6 +14,7 @@ import {
   SplitContextAndViewer,
   CustomizedAnnotations,
   Playground,
+  ZoomOnSelectedAnnotation,
   BoxAndArrows
 } from './cognite.stories.tsx';
 
@@ -122,6 +123,12 @@ The `draw()` function allows you to define a canvas and draw any shape you like.
 
 <Canvas>
   <Story story={CustomizedAnnotations} />
+</Canvas>
+
+## Programatically zoom on selected annotation
+
+<Canvas>
+  <Story story={ZoomOnSelectedAnnotation} />
 </Canvas>
 
 ## Box and arrows

--- a/stories/cognite.stories.tsx
+++ b/stories/cognite.stories.tsx
@@ -20,7 +20,6 @@ import {
   useExtractFromCanvas,
   useDownloadPDF,
   useZoomControls,
-  useAnnotations,
 } from "../src/Cognite/FileViewerContext";
 import styled from "styled-components";
 

--- a/stories/cognite.stories.tsx
+++ b/stories/cognite.stories.tsx
@@ -147,39 +147,81 @@ const Wrapper = styled.div`
   }
 `;
 
+export const ZoomOnSelectedAnnotation = () => {
+  const [annotations, setAnnotations] = useState<CogniteAnnotation[]>([]);
+  const [zoomedAnnotation, setZoomedAnnotation] = useState<CogniteAnnotation>();
+  const scale = 0.3;
+
+  useEffect(() => {
+    (async () => {
+      const annotationsFromCdf = await listAnnotationsForFile(pdfSdk, pdfFile);
+      setAnnotations(
+        annotationsFromCdf.concat([
+          {
+            id: 123,
+            label: "David",
+            createdTime: new Date(),
+            lastUpdatedTime: new Date(),
+            type: "tmp_annotation",
+            status: "unhandled",
+            box: { xMin: 0.1, xMax: 0.2, yMin: 0.1, yMax: 0.2 },
+            version: 5,
+            page: 1,
+            source: "tmp",
+          },
+        ])
+      );
+    })();
+  }, []);
+
+  const onZoomOnRandomAnnotation = () => {
+    const randomAnnotationIndex = Math.floor(
+      Math.random() * annotations.length
+    );
+    const randomAnnotation = annotations[
+      randomAnnotationIndex
+    ] as CogniteAnnotation;
+    setZoomedAnnotation(randomAnnotation);
+  };
+
+  return (
+    <div style={{ height: "100%", width: "100%", display: "flex" }}>
+      <Wrapper>
+        <Button onClick={() => onZoomOnRandomAnnotation()}>
+          Zoom on random annotation
+        </Button>
+      </Wrapper>
+      <CogniteFileViewer
+        sdk={pdfSdk}
+        file={pdfFile}
+        disableAutoFetch={true}
+        annotations={annotations}
+        zoomOnAnnotation={
+          zoomedAnnotation && { annotation: zoomedAnnotation, scale }
+        }
+      />
+    </div>
+  );
+};
+
 export const SplitContextAndViewer = () => {
   const AnotherComponent = () => {
     // This component now has access to all of the utilities and props of the viewer!
     const download = useDownloadPDF();
-    const { zoomIn, zoomOut, zoomOnAnnotation, reset } = useZoomControls();
+    const { zoomIn, zoomOut, reset } = useZoomControls();
     const extract = useExtractFromCanvas();
     const {
       selectedAnnotations,
       setSelectedAnnotations,
     } = useSelectedAnnotations();
-    const { annotations } = useAnnotations();
 
     const [selectedAnnotation] = selectedAnnotations;
-
-    const onZoomOnRandomAnnotation = () => {
-      const randomAnnotationIndex = Math.floor(
-        Math.random() * annotations.length
-      );
-      const randomAnnotation = annotations[
-        randomAnnotationIndex
-      ] as CogniteAnnotation;
-      const scale = 0.3;
-      zoomOnAnnotation!(randomAnnotation, scale);
-    };
 
     return (
       <Wrapper>
         <Button onClick={() => download!("testing.pdf")}>Download</Button>
         <Button onClick={() => zoomIn!()}>Zoom In</Button>
         <Button onClick={() => zoomOut!()}>Zoom Out</Button>
-        <Button onClick={() => onZoomOnRandomAnnotation()}>
-          Zoom on random annotation
-        </Button>
         <Button onClick={() => reset!()}>Reset</Button>
         {selectedAnnotation && (
           <Button onClick={() => setSelectedAnnotations([])}>


### PR DESCRIPTION
zoomOnAnnotation is no longer returned with the provider, it is now a callback. Per request from @bdimitrijoski 