### PR TITLE
fix: clean up dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,12 +97,9 @@
     "pdf-lib": "^1.12.0",
     "pdfjs-dist": "2.6.347",
     "react-archer": "^3.0.0",
-    "react-draggable": "^4.4.3",
     "react-is": "^17.0.1",
     "react-splitter-layout": "^4.0.0",
-    "reselect": "^4.0.0",
-    "styled-components": "^5.2.0",
-    "uuid": "^8.3.0"
+    "styled-components": "^5.2.0"
   },
   "peerDependencies": {
     "@cognite/cogs.js": "^2.4.2"

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@babel/preset-env": "^7.12.7",
     "@babel/preset-react": "^7.12.7",
     "@babel/preset-typescript": "^7.12.7",
+    "@cognite/cogs.js": "^2.4.2",
     "@commitlint/cli": "^11.0.0",
     "@commitlint/config-conventional": "^11.0.0",
     "@rollup/plugin-alias": "^3.1.1",
@@ -73,8 +74,8 @@
     "lint-staged": "^10.5.2",
     "prettier": "^2.2.1",
     "react": "^17.0.1",
-    "react-dom": "^17.0.1",
     "react-docgen-typescript-loader": "^3.7.2",
+    "react-dom": "^17.0.1",
     "rollup": "^2.34.2",
     "rollup-plugin-node-polyfills": "^0.2.1",
     "rollup-plugin-typescript2": "^0.29.0",
@@ -82,8 +83,7 @@
     "ts-jest": "^26.4.1",
     "tslint": "^6.1.3",
     "tslint-config-prettier": "^1.18.0",
-    "tslint-react": "^5.0.0",
-    "@cognite/cogs.js": "^2.4.2"
+    "tslint-react": "^5.0.0"
   },
   "dependencies": {
     "@cognite/annotations": "^1.1.0",
@@ -91,6 +91,7 @@
     "@storybook/addon-knobs": "^6.1.10",
     "@types/lodash": "^4.14.165",
     "@types/react-splitter-layout": "^3.0.0",
+    "lodash": "^4.17.21",
     "parse-color": "^1.0.0",
     "pdf-lib": "^1.12.0",
     "pdfjs-dist": "2.6.347",

--- a/package.json
+++ b/package.json
@@ -55,15 +55,18 @@
     "@storybook/addon-docs": "^6.1.10",
     "@storybook/addon-essentials": "^6.1.10",
     "@storybook/addon-info": "^5.3.21",
+    "@storybook/addon-knobs": "^6.1.10",
     "@storybook/addon-links": "^6.1.10",
     "@storybook/addon-storysource": "^6.1.10",
     "@storybook/addons": "^6.1.10",
     "@storybook/react": "^6.1.10",
     "@svgr/rollup": "^5.5.0",
     "@types/jest": "^26.0.14",
+    "@types/lodash": "^4.14.165",
     "@types/pdfjs-dist": "^2.1.5",
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",
+    "@types/react-splitter-layout": "^3.0.0",
     "@types/storybook__react": "^5.2.1",
     "@types/styled-components": "^5.1.4",
     "babel-loader": "^8.2.2",
@@ -83,14 +86,12 @@
     "ts-jest": "^26.4.1",
     "tslint": "^6.1.3",
     "tslint-config-prettier": "^1.18.0",
-    "tslint-react": "^5.0.0"
+    "tslint-react": "^5.0.0",
+    "typescript": "^4.1.2"
   },
   "dependencies": {
     "@cognite/annotations": "^1.1.0",
     "@cognite/sdk": "^3.3.0",
-    "@storybook/addon-knobs": "^6.1.10",
-    "@types/lodash": "^4.14.165",
-    "@types/react-splitter-layout": "^3.0.0",
     "lodash": "^4.17.21",
     "parse-color": "^1.0.0",
     "pdf-lib": "^1.12.0",
@@ -101,7 +102,6 @@
     "react-splitter-layout": "^4.0.0",
     "reselect": "^4.0.0",
     "styled-components": "^5.2.0",
-    "typescript": "^4.1.2",
     "uuid": "^8.3.0"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12932,7 +12932,7 @@ react-dom@^17.0.1:
     object-assign "^4.1.1"
     scheduler "^0.20.1"
 
-react-draggable@^4.0.3, react-draggable@^4.4.3:
+react-draggable@^4.0.3:
   version "4.4.3"
   resolved "https://registry.yarnpkg.com/react-draggable/-/react-draggable-4.4.3.tgz#0727f2cae5813e36b0e4962bf11b2f9ef2b406f3"
   integrity sha512-jV4TE59MBuWm7gb6Ns3Q1mxX8Azffb7oTtDtBgFkxRvhDp38YAARmRplrj0+XGkhOJB5XziArX+4HUUABtyZ0w==
@@ -13632,11 +13632,6 @@ require-main-filename@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
   integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
-
-reselect@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.0.0.tgz#f2529830e5d3d0e021408b246a206ef4ea4437f7"
-  integrity sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA==
 
 resize-observer-polyfill@1.5.0:
   version "1.5.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10364,6 +10364,11 @@ lodash@^4.0.1, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.15, lodash@^4.17.1
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
 
+lodash@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+
 log-symbols@^2.1.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-2.2.0.tgz#5740e1c5d6f0dfda4ad9323b5332107ef6b4c40a"


### PR DESCRIPTION
1. Move dev deps from `dependencies` to `devDependencies`
2. Add missing dependency
3. Remove unused dependencies 

Some of the diff in package.json is just jest moving stuff around in alphabetical order 