### PR TITLE
feat: base64 support for pdf files

### DIFF
--- a/src/ReactPictureAnnotation.tsx
+++ b/src/ReactPictureAnnotation.tsx
@@ -156,14 +156,17 @@ export class ReactPictureAnnotation extends React.Component<IReactPictureAnnotat
   private lastPinchLength?: number;
 
   private _PDF_DOC?: PDFDocumentProxy;
+  private pdfBase64Prefix = "data:application/pdf;base64,";
 
   public componentDidMount = async () => {
     const currentCanvas = this.canvasRef.current;
     const currentImageCanvas = this.imageCanvasRef.current;
     if (this.props.pdf) {
       try {
-        this._PDF_DOC = await pdfjs.getDocument({ url: this.props.pdf })
-          .promise;
+        const getDocParams = this.props.pdf.startsWith(this.pdfBase64Prefix)
+          ? { data: atob(this.props.pdf.replace(this.pdfBase64Prefix, "")) }
+          : { url: this.props.pdf };
+        this._PDF_DOC = await pdfjs.getDocument(getDocParams).promise;
         if (this.props.onPDFLoaded) {
           this.props.onPDFLoaded({ pages: this._PDF_DOC.numPages });
         }
@@ -213,7 +216,11 @@ export class ReactPictureAnnotation extends React.Component<IReactPictureAnnotat
     if (prevProps.pdf !== pdf) {
       if (pdf) {
         try {
-          this._PDF_DOC = await pdfjs.getDocument({ url: pdf }).promise;
+          const getDocParams = pdf.startsWith(this.pdfBase64Prefix)
+            ? { data: atob(pdf.replace(this.pdfBase64Prefix, "")) }
+            : { url: pdf };
+
+          this._PDF_DOC = await pdfjs.getDocument(getDocParams).promise;
           if (this.props.onPDFLoaded) {
             this.props.onPDFLoaded({ pages: this._PDF_DOC.numPages });
           }

--- a/stories/index.stories.tsx
+++ b/stories/index.stories.tsx
@@ -955,6 +955,71 @@ storiesOf("Default Viewer", module)
         </div>
       </Wrapper>
     );
+  })
+  .add("PDF in Base64", () => {
+    const pdfBase64String =
+      "JVBERi0xLjcKCjEgMCBvYmogICUgZW50cnkgcG9pbnQKPDwKICAvVHlwZSAvQ2F0YWxvZwog" +
+      "IC9QYWdlcyAyIDAgUgo+PgplbmRvYmoKCjIgMCBvYmoKPDwKICAvVHlwZSAvUGFnZXMKICAv" +
+      "TWVkaWFCb3ggWyAwIDAgMjAwIDIwMCBdCiAgL0NvdW50IDEKICAvS2lkcyBbIDMgMCBSIF0K" +
+      "Pj4KZW5kb2JqCgozIDAgb2JqCjw8CiAgL1R5cGUgL1BhZ2UKICAvUGFyZW50IDIgMCBSCiAg" +
+      "L1Jlc291cmNlcyA8PAogICAgL0ZvbnQgPDwKICAgICAgL0YxIDQgMCBSIAogICAgPj4KICA+" +
+      "PgogIC9Db250ZW50cyA1IDAgUgo+PgplbmRvYmoKCjQgMCBvYmoKPDwKICAvVHlwZSAvRm9u" +
+      "dAogIC9TdWJ0eXBlIC9UeXBlMQogIC9CYXNlRm9udCAvVGltZXMtUm9tYW4KPj4KZW5kb2Jq" +
+      "Cgo1IDAgb2JqICAlIHBhZ2UgY29udGVudAo8PAogIC9MZW5ndGggNDQKPj4Kc3RyZWFtCkJU" +
+      "CjcwIDUwIFRECi9GMSAxMiBUZgooSGVsbG8sIHdvcmxkISkgVGoKRVQKZW5kc3RyZWFtCmVu" +
+      "ZG9iagoKeHJlZgowIDYKMDAwMDAwMDAwMCA2NTUzNSBmIAowMDAwMDAwMDEwIDAwMDAwIG4g" +
+      "CjAwMDAwMDAwNzkgMDAwMDAgbiAKMDAwMDAwMDE3MyAwMDAwMCBuIAowMDAwMDAwMzAxIDAw" +
+      "MDAwIG4gCjAwMDAwMDAzODAgMDAwMDAgbiAKdHJhaWxlcgo8PAogIC9TaXplIDYKICAvUm9v" +
+      "dCAxIDAgUgo+PgpzdGFydHhyZWYKNDkyCiUlRU9G";
+
+    const [pdf, setPdf] = useState<string>();
+
+    const [annotationData, setAnnotationData] = useState<
+      IAnnotation<IShapeData>[]
+    >(defaultAnnotations);
+
+    const [selectedIds, setSelectedIds] = useState<string[]>(["a"]);
+    const annotationRef = React.createRef<ReactPictureAnnotation>();
+
+    const fromUrl = () => {
+      setPdf(
+        "https://mozilla.github.io/pdf.js/web/compressed.tracemonkey-pldi-09.pdf"
+      );
+    };
+
+    const fromBase64 = () => {
+      setPdf(`data:application/pdf;base64,${pdfBase64String}`);
+    };
+    return (
+      <Wrapper>
+        <button onClick={fromUrl}>Pdf from URL</button>
+        <button onClick={fromBase64}>Pdf from base64</button>
+        <ReactPictureAnnotation
+          ref={annotationRef}
+          hoverable={false}
+          page={1}
+          width={800}
+          height={600}
+          image={undefined}
+          annotationData={annotationData}
+          onChange={(data) => setAnnotationData(data)}
+          selectedIds={selectedIds}
+          onSelect={(e) => {
+            setSelectedIds(e);
+            action("onSelect")(e);
+          }}
+          pdf={pdf}
+        />
+        <div
+          style={{
+            position: "absolute",
+            bottom: 12,
+            left: "50%",
+            right: "50%",
+          }}
+        />
+      </Wrapper>
+    );
   });
 
 const Wrapper = styled.div`


### PR DESCRIPTION
Added support for passing pdf as base64 encoded strings. Useful if you want to cache the pdfs.
See storybook for usage.