### PR TITLE
feat: added file loaded event to the file viewer

### DIFF
--- a/src/Cognite/FileViewer.tsx
+++ b/src/Cognite/FileViewer.tsx
@@ -107,6 +107,11 @@ export type ViewerProps = {
   onAnnotationSelected?: (
     annotation: (CogniteAnnotation | ProposedCogniteAnnotation)[]
   ) => void;
+
+  /**
+   * Callback function to be called when the file is loaded
+   */
+  onFileLoaded?: () => void;
   /**
    * Should pagination be shown, and what size? One page files will have no pagination displayed regardless of settings!
    */
@@ -162,6 +167,7 @@ export const FileViewer = ({
   renderAnnotation = convertCogniteAnnotationToIAnnotation,
   renderArrowPreview,
   arrowPreviewOptions,
+  onFileLoaded,
 }: ViewerProps) => {
   const {
     annotations,
@@ -497,6 +503,10 @@ export const FileViewer = ({
         onPDFLoaded={async ({ pages }) => {
           setLoading(false);
           setTotalPages(pages);
+
+          if (onFileLoaded) {
+            onFileLoaded();
+          }
         }}
         zoomOnAnnotation={zoomOnAnnotation}
       />

--- a/stories/cognite.stories.tsx
+++ b/stories/cognite.stories.tsx
@@ -183,6 +183,12 @@ export const ZoomOnSelectedAnnotation = () => {
     setZoomedAnnotation(randomAnnotation);
   };
 
+  const onFileLoaded = () => {
+    setTimeout(() => {
+      onZoomOnRandomAnnotation();
+    }, 200); // wait to finish rendering the annotations
+  };
+
   return (
     <div style={{ height: "100%", width: "100%", display: "flex" }}>
       <Wrapper>
@@ -195,6 +201,7 @@ export const ZoomOnSelectedAnnotation = () => {
         file={pdfFile}
         disableAutoFetch={true}
         annotations={annotations}
+        onFileLoaded={onFileLoaded}
         zoomOnAnnotation={
           zoomedAnnotation && { annotation: zoomedAnnotation, scale }
         }

--- a/stories/index.stories.tsx
+++ b/stories/index.stories.tsx
@@ -1005,7 +1005,7 @@ storiesOf("Default Viewer", module)
 
     const [annotationData, setAnnotationData] = useState<
       IAnnotation<IShapeData>[]
-    >();
+    >([]);
 
     const [selectedIds, setSelectedIds] = useState<string[]>(["a"]);
     const annotationRef = React.createRef<ReactPictureAnnotation>();

--- a/stories/index.stories.tsx
+++ b/stories/index.stories.tsx
@@ -972,22 +972,53 @@ storiesOf("Default Viewer", module)
       "MDAwIG4gCjAwMDAwMDAzODAgMDAwMDAgbiAKdHJhaWxlcgo8PAogIC9TaXplIDYKICAvUm9v" +
       "dCAxIDAgUgo+PgpzdGFydHhyZWYKNDkyCiUlRU9G";
 
+    const customAnnotations = [
+      {
+        id: "a",
+        comment: "HA HA HA",
+        mark: {
+          type: "RECT",
+          width: 161,
+          height: 165,
+          x: 229,
+          y: 92,
+          strokeColor: "red",
+          backgroundColor: "rgba(255,0,0,0.2)",
+        },
+      },
+      {
+        id: "b",
+        comment: "HA HA HA 2",
+        mark: {
+          type: "RECT",
+          width: 116,
+          height: 116,
+          x: 429,
+          y: 192,
+          strokeColor: "green",
+          backgroundColor: "rgba(0,255,0,0.2)",
+        },
+      },
+    ];
+
     const [pdf, setPdf] = useState<string>();
 
     const [annotationData, setAnnotationData] = useState<
       IAnnotation<IShapeData>[]
-    >(defaultAnnotations);
+    >();
 
     const [selectedIds, setSelectedIds] = useState<string[]>(["a"]);
     const annotationRef = React.createRef<ReactPictureAnnotation>();
 
     const fromUrl = () => {
+      setAnnotationData(defaultAnnotations);
       setPdf(
         "https://mozilla.github.io/pdf.js/web/compressed.tracemonkey-pldi-09.pdf"
       );
     };
 
     const fromBase64 = () => {
+      setAnnotationData(customAnnotations);
       setPdf(`data:application/pdf;base64,${pdfBase64String}`);
     };
     return (


### PR DESCRIPTION
Added `onFileLoaded` event to the FileViewer so it can be used to perform some actions after the pdf file has finished loading.

See "Zoom on annotation" story for usage.