### PR TITLE
fix: pinch length

### DIFF
--- a/src/Cognite/FileViewer.tsx
+++ b/src/Cognite/FileViewer.tsx
@@ -140,6 +140,10 @@ export type ViewerProps = {
    * Sets the annotation that the file should zoom on
    */
   zoomOnAnnotation?: { annotation: CogniteAnnotation; scale?: number };
+  /**
+   * Allows to customize the pinch zoom scale.
+   */
+  pinchScaleModifier?: number;
 };
 
 export const FileViewer = ({
@@ -168,6 +172,7 @@ export const FileViewer = ({
   renderArrowPreview,
   arrowPreviewOptions,
   onFileLoaded,
+  pinchScaleModifier,
 }: ViewerProps) => {
   const {
     annotations,
@@ -509,6 +514,7 @@ export const FileViewer = ({
           }
         }}
         zoomOnAnnotation={zoomOnAnnotation}
+        pinchScaleModifier={pinchScaleModifier}
       />
       {totalPages > 1 && pagination && (
         <DocumentPagination

--- a/src/ReactPictureAnnotation.tsx
+++ b/src/ReactPictureAnnotation.tsx
@@ -73,6 +73,7 @@ interface IReactPictureAnnotationProps {
   onLoading: (loading: boolean) => void;
   onReady?: (element: ReactPictureAnnotation) => void;
   mouseWheelScaleModifier?: number;
+  pinchScaleModifier?: number;
   zoomOnAnnotation?: { annotation: any; scale?: number };
 }
 
@@ -1187,10 +1188,14 @@ export class ReactPictureAnnotation extends React.Component<IReactPictureAnnotat
   };
 
   private handlePinchChange = (touches: React.TouchList) => {
+    const { pinchScaleModifier = 0.001 } = this.props;
     const length = getPinchLength(touches);
     const midpoint = getPinchMidpoint(touches);
+    const zoomDiff =
+      (length - Number(this.lastPinchLength)) * pinchScaleModifier;
+
     let scale = this.lastPinchLength
-      ? (this.scaleState.scale + length) / this.lastPinchLength // sometimes we get a touchchange before a touchstart when pinching
+      ? this.scaleState.scale + zoomDiff
       : this.scaleState.scale;
 
     if (scale > 10) {
@@ -1209,6 +1214,7 @@ export class ReactPictureAnnotation extends React.Component<IReactPictureAnnotat
     this.scaleState.scale = scale;
 
     this.setState({ imageScale: this.scaleState });
+    this.lastPinchLength = length;
 
     requestAnimationFrame(() => {
       this.onShapeChange();

--- a/src/ReactPictureAnnotation.tsx
+++ b/src/ReactPictureAnnotation.tsx
@@ -121,7 +121,6 @@ export class ReactPictureAnnotation extends React.Component<IReactPictureAnnotat
     drawLabel: true,
     usePercentage: true,
     onLoading: () => true,
-    mouseWheelScaleModifier: 0.01,
   };
 
   public shapes: IShape[] = [];
@@ -1191,7 +1190,7 @@ export class ReactPictureAnnotation extends React.Component<IReactPictureAnnotat
     const length = getPinchLength(touches);
     const midpoint = getPinchMidpoint(touches);
     let scale = this.lastPinchLength
-      ? (this.scaleState.scale * length) / this.lastPinchLength // sometimes we get a touchchange before a touchstart when pinching
+      ? (this.scaleState.scale + length) / this.lastPinchLength // sometimes we get a touchchange before a touchstart when pinching
       : this.scaleState.scale;
 
     if (scale > 10) {
@@ -1236,7 +1235,7 @@ export class ReactPictureAnnotation extends React.Component<IReactPictureAnnotat
     // }
 
     const { scale: preScale } = this.scaleState;
-    const { mouseWheelScaleModifier = 0.01 } = this.props;
+    const { mouseWheelScaleModifier = 0.001 } = this.props;
     // this.scaleState.scale -= event.deltaY * 0.005;
     const { offsetX, offsetY, ctrlKey, deltaY, deltaX } = event;
 

--- a/stories/cognite.stories.tsx
+++ b/stories/cognite.stories.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useMemo } from "react";
 import { action } from "@storybook/addon-actions";
-import { boolean, select } from "@storybook/addon-knobs";
+import { boolean, select, number } from "@storybook/addon-knobs";
 import { CogniteFileViewer, ViewerEditCallbacks } from "../src";
 import {
   imgSdk,
@@ -52,6 +52,12 @@ export const AllowCustomization = () => {
       file={pdfFile}
       disableAutoFetch={true}
       annotations={annotations}
+      pinchScaleModifier={number("Pinch zoom scale modifier", 0.001, {
+        range: true,
+        min: 0.0001,
+        max: 100,
+        step: 0.0001,
+      })}
     />
   );
 };


### PR DESCRIPTION
Pinch zoom is now the same length as the actual pinch instead of being a modifier.