### PR TITLE
chore: opening a link upon clicking an annotation

### DIFF
--- a/stories/cognite.stories.mdx
+++ b/stories/cognite.stories.mdx
@@ -15,6 +15,7 @@ import {
   CustomizedAnnotations,
   Playground,
   ZoomOnSelectedAnnotation,
+  AllowLinkClick,
   BoxAndArrows
 } from './cognite.stories.tsx';
 
@@ -176,6 +177,12 @@ You can drag all of the boxes around, but their positions will reset once the co
 
 It is a callback that allows you to access the `offsetX` and `offsetY` for the dragged arrow box, identified by the `annotationId` field. 
 You can store that value somewhere, and then pass it back to the `arrowPreviewOptions.customOffset[annotationId]` if you want to recreate it!
+
+## Allow link click
+
+<Canvas>
+  <Story story={AllowLinkClick} />
+</Canvas>
 
 ## Playground
 

--- a/stories/cognite.stories.tsx
+++ b/stories/cognite.stories.tsx
@@ -124,7 +124,7 @@ export const AllowControlledEditing = () => {
       onAnnotationSelected={handleAnnotationSelection}
       renderItemPreview={(anno) => (
         <>
-          <span>{anno[0].label}</span>
+          <span>{anno[0]?.label ?? "UNKNOWN"}</span>
           <Button
             icon="Delete"
             onClick={() =>
@@ -478,6 +478,42 @@ export const BoxAndArrows = () => {
         renderArrowPreview={renderArrowPreview}
       />
     </div>
+  );
+};
+
+export const AllowLinkClick = () => {
+  const [annotations, setAnnotations] = useState<CogniteAnnotation[]>([]);
+
+  const appendLinkToAnnotation = async () => {
+    const annotationsFromCdf = await listAnnotationsForFile(pdfSdk, pdfFile);
+    const singleAnnotation = annotationsFromCdf[0];
+    const fixedAnnotation = {
+      ...singleAnnotation,
+      metadata: {
+        ...(singleAnnotation.metadata ?? {}),
+        url: "https://en.wikipedia.org/wiki/Kitten",
+      },
+    };
+    setAnnotations([fixedAnnotation]);
+  };
+
+  useEffect(() => {
+    appendLinkToAnnotation();
+  }, []);
+
+  return (
+    <CogniteFileViewer
+      disableAutoFetch={true}
+      sdk={pdfSdk}
+      file={pdfFile}
+      annotations={annotations}
+      onAnnotationSelected={(annotation) => {
+        const url = annotation[0]?.metadata?.url;
+        if (url) {
+          window.open(url, "_blank");
+        }
+      }}
+    />
   );
 };
 


### PR DESCRIPTION
This PR adds a story showcasing on how to trigger link open upon selecting an annotation.