### PR TITLE
fix: export hooks

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,3 +4,4 @@ export * from "./Shape";
 export * from "./Annotation";
 export * from "./ReactPictureAnnotation";
 export * from "./Cognite";
+export * from "./context";


### PR DESCRIPTION
Hooks were not exported from lib and it has created breaking changes in the apps that use them.
Re-exported again.